### PR TITLE
Fix bazel test -c opt ...:all

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -636,7 +636,9 @@ $_write_methods_$
           emboss_reserved_local_maybe_new_value.ValueOrDefault());
     }
     void Write($_logical_type_$ emboss_reserved_local_value) {
-      EMBOSS_CHECK(TryToWrite(emboss_reserved_local_value));
+      const bool result = TryToWrite(emboss_reserved_local_value);
+      (void)result;
+      EMBOSS_CHECK(result);
     }
     void UncheckedWrite($_logical_type_$ emboss_reserved_local_value) {
       view_.$_destination_$.UncheckedWrite(($_transform_$).ValueOrDefault());

--- a/compiler/back_end/cpp/testcode/auto_array_size_test.cc
+++ b/compiler/back_end/cpp/testcode/auto_array_size_test.cc
@@ -205,7 +205,9 @@ TEST(AutoSizeView, CanReadAutoArrays) {
   EXPECT_EQ(0x30U, view.four_byte_array()[2].Read());
   EXPECT_EQ(0x40U, view.four_byte_array()[3].Read());
   EXPECT_EQ(4U, view.four_byte_array().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.four_byte_array()[4].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x11U, view.four_struct_array()[0].a().Read());
   EXPECT_EQ(0x12U, view.four_struct_array()[0].b().Read());
   EXPECT_EQ(0x21U, view.four_struct_array()[1].a().Read());
@@ -215,7 +217,9 @@ TEST(AutoSizeView, CanReadAutoArrays) {
   EXPECT_EQ(0x41U, view.four_struct_array()[3].a().Read());
   EXPECT_EQ(0x42U, view.four_struct_array()[3].b().Read());
   EXPECT_EQ(8U, view.four_struct_array().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.four_struct_array()[4].a().Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x50U, view.dynamic_byte_array()[0].Read());
   EXPECT_EQ(0x60U, view.dynamic_byte_array()[1].Read());
   EXPECT_EQ(0x70U, view.dynamic_byte_array()[2].Read());
@@ -236,14 +240,18 @@ TEST(AutoSizeWriter, CanWriteAutoArrays) {
   auto writer = MakeAutoSizeView(&buffer);
   writer.array_size().Write(0);
   EXPECT_EQ(13U, writer.SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer.dynamic_byte_array()[0].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   writer.array_size().Write(3);
   EXPECT_EQ(22U, writer.SizeInBytes());
   writer.four_byte_array()[0].Write(0x10);
   writer.four_byte_array()[1].Write(0x20);
   writer.four_byte_array()[2].Write(0x30);
   writer.four_byte_array()[3].Write(0x40);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer.four_byte_array()[4].Write(0), "");
+#endif  // EMBOSS_CHECK_ABORTS
   writer.four_struct_array()[0].a().Write(0x11);
   writer.four_struct_array()[0].b().Write(0x12);
   writer.four_struct_array()[1].a().Write(0x21);

--- a/compiler/back_end/cpp/testcode/bcd_test.cc
+++ b/compiler/back_end/cpp/testcode/bcd_test.cc
@@ -95,9 +95,11 @@ TEST(BcdSizesWriter, CanWriteBcd) {
   EXPECT_EQ(::std::vector</**/ ::std::uint8_t>(kBcd, kBcd + sizeof kBcd),
             ::std::vector</**/ ::std::uint8_t>(buffer, buffer + sizeof buffer));
 
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer.one_byte().Write(100), "");
   EXPECT_DEATH(writer.three_byte().Write(1445566), "");
   EXPECT_DEATH(writer.ten_bit().Write(400), "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 TEST(BcdSizesView, OkIsTrueForGoodBcd) {
@@ -146,6 +148,7 @@ TEST(BcdSizesView, UncheckedReadingInvalidBcdDoesNotCrash) {
   view.twelve_bit().UncheckedRead();
 }
 
+#if EMBOSS_CHECK_ABORTS
 TEST(BcdSizesView, ReadingInvalidBcdCrashes) {
   auto view = BcdSizesView(kBadBcd, sizeof kBadBcd);
   EXPECT_DEATH(view.one_byte().Read(), "");
@@ -161,6 +164,7 @@ TEST(BcdSizesView, ReadingInvalidBcdCrashes) {
   EXPECT_DEATH(view.ten_bit().Read(), "");
   EXPECT_DEATH(view.twelve_bit().Read(), "");
 }
+#endif  // EMBOSS_CHECK_ABORTS
 
 TEST(BcdSizesView, OkIsFalseForBadBcd) {
   auto view = BcdSizesView(kBadBcd, sizeof kBadBcd);
@@ -270,30 +274,40 @@ TEST(BcdSizesView, UncheckedEquals) {
   auto y = BcdSizesView(&buf_y);
 
   EXPECT_TRUE(x.UncheckedEquals(x));
-  EXPECT_DEATH(x.Equals(x), "");
   EXPECT_TRUE(y.UncheckedEquals(y));
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(x.Equals(x), "");
   EXPECT_DEATH(y.Equals(y), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   EXPECT_TRUE(x.UncheckedEquals(y));
-  EXPECT_DEATH(x.Equals(y), "");
   EXPECT_TRUE(y.UncheckedEquals(x));
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(x.Equals(y), "");
   EXPECT_DEATH(y.Equals(x), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   EXPECT_TRUE(x_const.UncheckedEquals(y));
-  EXPECT_DEATH(x_const.Equals(y), "");
   EXPECT_TRUE(y.UncheckedEquals(x_const));
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(x_const.Equals(y), "");
   EXPECT_DEATH(y.Equals(x_const), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   ++buf_y[1];
   EXPECT_FALSE(x.UncheckedEquals(y));
-  EXPECT_DEATH(x.Equals(y), "");
   EXPECT_FALSE(y.UncheckedEquals(x));
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(x.Equals(y), "");
   EXPECT_DEATH(y.Equals(x), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   EXPECT_FALSE(x_const.UncheckedEquals(y));
-  EXPECT_DEATH(x_const.Equals(y), "");
   EXPECT_FALSE(y.UncheckedEquals(x_const));
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(x_const.Equals(y), "");
   EXPECT_DEATH(y.Equals(x_const), "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 }  // namespace

--- a/compiler/back_end/cpp/testcode/bits_test.cc
+++ b/compiler/back_end/cpp/testcode/bits_test.cc
@@ -65,7 +65,9 @@ TEST(Bits, StructOfBits) {
   struct_of_bits.four_byte().low_nibble().Write(115);
   EXPECT_EQ(0xff, data[3]);
   // Out-of-[range] write.
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(struct_of_bits.four_byte().low_nibble().Write(100), "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 TEST(Bits, StructOfBitsFromText) {

--- a/compiler/back_end/cpp/testcode/condition_test.cc
+++ b/compiler/back_end/cpp/testcode/condition_test.cc
@@ -61,6 +61,7 @@ TEST(Conditional, WithConditionFalseStructIsOkButConditionalFieldIsNot) {
   EXPECT_FALSE(writer.xc().Ok());
 }
 
+#if EMBOSS_CHECK_ABORTS
 TEST(Conditional, BasicConditionFalseReadCrashes) {
   ::std::uint8_t buffer[2] = {1, 2};
   auto writer = BasicConditionalWriter(buffer, sizeof buffer);
@@ -72,6 +73,7 @@ TEST(Conditional, BasicConditionFalseWriteCrashes) {
   auto writer = BasicConditionalWriter(buffer, sizeof buffer);
   EXPECT_DEATH(writer.xc().Write(3), "");
 }
+#endif  // EMBOSS_CHECK_ABORTS
 
 TEST(Conditional, BasicConditionTrueSizeIncludesConditionalField) {
   ::std::uint8_t buffer[2] = {0, 2};
@@ -150,7 +152,9 @@ TEST(Conditional,
 TEST(Conditional, NegativeConditionFalseReadCrashes) {
   ::std::uint8_t buffer1[2] = {0, 2};
   auto writer1 = NegativeConditionalWriter(buffer1, sizeof buffer1);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer1.xc().Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   ::std::uint8_t buffer2[2] = {0, 0};
   auto writer2 = BasicConditionalWriter(buffer2, sizeof buffer2);
@@ -163,7 +167,9 @@ TEST(Conditional, NegativeConditionFalseReadCrashes) {
 TEST(Conditional, NegativeConditionFalseWriteCrashes) {
   ::std::uint8_t buffer1[2] = {0, 2};
   auto writer1 = NegativeConditionalWriter(buffer1, sizeof buffer1);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer1.xc().Write(3), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   ::std::uint8_t buffer2[2] = {0, 2};
   auto writer2 = NegativeConditionalWriter(buffer2, sizeof buffer2);

--- a/compiler/back_end/cpp/testcode/dynamic_size_test.cc
+++ b/compiler/back_end/cpp/testcode/dynamic_size_test.cc
@@ -50,7 +50,9 @@ TEST(MessageView, FieldsAreCorrect) {
   EXPECT_EQ(5U, view.message()[4].Read());
   EXPECT_EQ(6U, view.message()[5].Read());
   EXPECT_EQ(6U, view.message().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.message()[6].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x0a090807U, view.crc32().Read());
 }
 
@@ -58,7 +60,9 @@ TEST(MessageView, FieldsAreCorrect) {
 TEST(MessageView, PaddingFieldWorks) {
   auto view = MessageView(&kMessage);
   EXPECT_EQ(0U, view.padding().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.padding()[0].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 static constexpr ::std::array</**/ ::std::uint8_t, 16> kPaddedMessage = {{
@@ -80,13 +84,17 @@ TEST(MessageView, PaddedMessageFieldsAreCorrect) {
   EXPECT_EQ(3U, view.padding()[2].Read());
   EXPECT_EQ(4U, view.padding()[3].Read());
   EXPECT_EQ(4U, view.padding().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.padding()[4].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(5U, view.message()[0].Read());
   EXPECT_EQ(6U, view.message()[1].Read());
   EXPECT_EQ(7U, view.message()[2].Read());
   EXPECT_EQ(8U, view.message()[3].Read());
   EXPECT_EQ(4U, view.message().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.message()[4].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x0c0b0a09U, view.crc32().Read());
 }
 
@@ -103,8 +111,10 @@ TEST(MessageView, Writer) {
     writer.message()[i].Write(i + 1);
   }
   EXPECT_EQ(12U, writer.SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer.message()[writer.message_length().Read()].Read(), "");
   EXPECT_DEATH(writer.padding()[0].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   writer.crc32().Write(0x0a090807);
   EXPECT_EQ(
       ::std::vector</**/ ::std::uint8_t>(kMessage.begin(), kMessage.end()),

--- a/compiler/back_end/cpp/testcode/enum_test.cc
+++ b/compiler/back_end/cpp/testcode/enum_test.cc
@@ -126,7 +126,9 @@ TEST(ManifestEntryWriter, CanWriteKind) {
                 kManifestEntry, kManifestEntry + sizeof kManifestEntry),
             ::std::vector</**/ ::std::uint8_t>(buffer, buffer + sizeof buffer));
 
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(writer.kind().Write(Kind::LARGE_VALUE), "");
+#endif  // EMBOSS_CHECK_ABORTS
   writer.kind().Write(static_cast<Kind>(0xff));
   EXPECT_EQ(static_cast<Kind>(0xff), writer.kind().Read());
   EXPECT_EQ(0xff, buffer[0]);

--- a/compiler/back_end/cpp/testcode/requires_test.cc
+++ b/compiler/back_end/cpp/testcode/requires_test.cc
@@ -118,7 +118,9 @@ TEST(RequiresBools, CouldWriteValue) {
   EXPECT_TRUE(view.must_be_false().CouldWriteValue(false));
   EXPECT_TRUE(view.alias_of_a_must_be_true().CouldWriteValue(true));
   EXPECT_FALSE(view.alias_of_a_must_be_true().CouldWriteValue(false));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.alias_of_a_must_be_true().Write(false), "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 TEST(RequiresEnums, Ok) {

--- a/compiler/back_end/cpp/testcode/virtual_field_test.cc
+++ b/compiler/back_end/cpp/testcode/virtual_field_test.cc
@@ -90,12 +90,14 @@ TEST(Computed, Values) {
   EXPECT_EQ(-250, view.product().Read());
 }
 
+#if EMBOSS_CHECK_ABORTS
 TEST(Computed, ReadFailsWhenUnderlyingFieldIsNotOk) {
   ::std::array<char, 0> values = {};
   const auto view = MakeStructureWithComputedValuesView(&values);
   EXPECT_DEATH(view.value().Read(), "");
   EXPECT_DEATH(view.doubled().Read(), "");
 }
+#endif  // EMBOSS_CHECK_ABORTS
 
 // Check the return types of nonstatic Read methods.
 static_assert(
@@ -189,7 +191,9 @@ TEST(ConditionalVirtual, ConditionChecks) {
   EXPECT_EQ(6, view.x_plus_one().UncheckedRead());
   view.x().Write(0x80000000U);
   EXPECT_FALSE(view.has_two_x().Value());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.two_x().Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_TRUE(view.has_x_plus_one().Value());
   EXPECT_EQ(0x80000001U, view.x_plus_one().Read());
 }
@@ -199,7 +203,9 @@ TEST(ConditionalVirtual, UncheckedRead) {
   const auto view = MakeStructureWithConditionalValueView(&values[0], 1);
   EXPECT_FALSE(view.Ok());
   EXPECT_FALSE(view.x().Ok());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(view.two_x().Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0, view.two_x().UncheckedRead());
 }
 

--- a/runtime/cpp/emboss_defines.h
+++ b/runtime/cpp/emboss_defines.h
@@ -68,7 +68,12 @@
 // translation units MUST be built with the same value of NDEBUG!)
 #if !defined(EMBOSS_CHECK)
 #define EMBOSS_CHECK(x) assert((x))
+#define EMBOSS_CHECK_ABORTS (!(NDEBUG))
 #endif  // !defined(EMBOSS_CHECK)
+
+#if !defined(EMBOSS_CHECK_ABORTS)
+#error "Custom EMBOSS_CHECK without EMBOSS_CHECK_ABORTS."
+#endif  // !defined(EMBOSS_CHECK_ABORTS)
 
 #if !defined(EMBOSS_CHECK_LE)
 #define EMBOSS_CHECK_LE(x, y) EMBOSS_CHECK((x) <= (y))
@@ -101,7 +106,12 @@
 // disable EMBOSS_DCHECK in situations where you do not disable EMBOSS_CHECK.
 #if !defined(EMBOSS_DCHECK)
 #define EMBOSS_DCHECK(x) assert((x))
+#define EMBOSS_DCHECK_ABORTS (!(NDEBUG))
 #endif  // !defined(EMBOSS_DCHECK)
+
+#if !defined(EMBOSS_DCHECK_ABORTS)
+#error "Custom EMBOSS_DCHECK without EMBOSS_DCHECK_ABORTS."
+#endif  // !defined(EMBOSS_DCHECK_ABORTS)
 
 #if !defined(EMBOSS_DCHECK_LE)
 #define EMBOSS_DCHECK_LE(x, y) EMBOSS_DCHECK((x) <= (y))

--- a/runtime/cpp/emboss_enum_view.h
+++ b/runtime/cpp/emboss_enum_view.h
@@ -54,7 +54,11 @@ class EnumView final {
   ValueType UncheckedRead() const {
     return static_cast<ValueType>(buffer_.UncheckedReadUInt());
   }
-  void Write(ValueType value) const { EMBOSS_CHECK(TryToWrite(value)); }
+  void Write(ValueType value) const {
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
+  }
   bool TryToWrite(ValueType value) const {
     if (!CouldWriteValue(value)) return false;
     if (!IsComplete()) return false;

--- a/runtime/cpp/emboss_prelude.h
+++ b/runtime/cpp/emboss_prelude.h
@@ -53,7 +53,11 @@ class FlagView final {
     return result;
   }
   bool UncheckedRead() const { return bit_block_.UncheckedReadUInt(); }
-  void Write(bool value) const { EMBOSS_CHECK(TryToWrite(value)); }
+  void Write(bool value) const {
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
+  }
   bool TryToWrite(bool value) const {
     if (!CouldWriteValue(value)) return false;
     if (!IsComplete()) return false;
@@ -174,7 +178,9 @@ class UIntView final {
                                                IntT>::type>::type>::value) ||
                 ::std::is_enum<IntT>::value>::type>
   void Write(IntT value) const {
-    EMBOSS_CHECK(TryToWrite(value));
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
   }
 
   template <typename IntT,
@@ -337,7 +343,9 @@ class IntView final {
                                                IntT>::type>::type>::value) ||
                 ::std::is_enum<IntT>::value>::type>
   void Write(IntT value) const {
-    EMBOSS_CHECK(TryToWrite(value));
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
   }
 
   template <typename IntT,
@@ -490,6 +498,7 @@ class IntView final {
         return -1;
       } else {
         EMBOSS_CHECK(false);
+        return -1;  // Return value if EMBOSS_CHECK is disabled.
       }
     } else {
       typename BitViewType::ValueType sign_bit =
@@ -605,7 +614,11 @@ class BcdView final {
   ValueType UncheckedRead() const {
     return ConvertToBinary(buffer_.UncheckedReadUInt());
   }
-  void Write(ValueType value) const { EMBOSS_CHECK(TryToWrite(value)); }
+  void Write(ValueType value) const {
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
+  }
   bool TryToWrite(ValueType value) const {
     if (!CouldWriteValue(value)) return false;
     if (!IsComplete()) return false;
@@ -720,7 +733,11 @@ class FloatView final {
   ValueType UncheckedRead() const {
     return ConvertToFloat(buffer_.UncheckedReadUInt());
   }
-  void Write(ValueType value) const { EMBOSS_CHECK(TryToWrite(value)); }
+  void Write(ValueType value) const {
+    const bool result = TryToWrite(value);
+    (void)result;
+    EMBOSS_CHECK(result);
+  }
   bool TryToWrite(ValueType value) const {
     if (!CouldWriteValue(value)) return false;
     if (!IsComplete()) return false;

--- a/runtime/cpp/emboss_text_util.h
+++ b/runtime/cpp/emboss_text_util.h
@@ -576,11 +576,11 @@ void WriteFloatToTextStream(Float n, Stream *stream,
   ::std::array<char, 30> buffer;
   // TODO(bolms): Figure out how to get ::std::snprintf to work on
   // microcontroller builds.
-  EMBOSS_CHECK_LE(
-      static_cast</**/ ::std::size_t>(::snprintf(
-          &(buffer[0]), buffer.size(), "%.*g",
-          FloatConstants<Float>::kPrintfPrecision(), static_cast<double>(n))),
-      buffer.size());
+  ::std::size_t snprintf_result = static_cast</**/ ::std::size_t>(::snprintf(
+      &(buffer[0]), buffer.size(), "%.*g",
+      FloatConstants<Float>::kPrintfPrecision(), static_cast<double>(n)));
+  (void)snprintf_result;  // Unused if EMBOSS_CHECK_LE is compiled out.
+  EMBOSS_CHECK_LE(snprintf_result, buffer.size());
   stream->Write(&buffer[0]);
 
   // TODO(bolms): Support digit grouping.

--- a/runtime/cpp/test/emboss_array_view_test.cc
+++ b/runtime/cpp/test/emboss_array_view_test.cc
@@ -55,7 +55,9 @@ TEST(ArrayView, Methods) {
   EXPECT_EQ(bytes[0], byte_array[0].Read());
   EXPECT_EQ(bytes[1], byte_array[1].Read());
   EXPECT_EQ(bytes[2], byte_array[2].Read());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(byte_array[sizeof bytes - 4].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(bytes[sizeof bytes - 4],
             byte_array[sizeof bytes - 4].UncheckedRead());
   EXPECT_TRUE(byte_array[sizeof bytes - 5].IsComplete());
@@ -75,7 +77,9 @@ TEST(ArrayView, Methods) {
   EXPECT_EQ(0x0d0e0f10U, uint32_array[0].Read());
   EXPECT_EQ(0x090a0b0cU, uint32_array[1].Read());
   EXPECT_EQ(0x05060708U, uint32_array[2].Read());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(uint32_array[3].Read(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x01020304U, uint32_array[3].UncheckedRead());
   EXPECT_TRUE(uint32_array[2].IsComplete());
   EXPECT_FALSE(uint32_array[3].IsComplete());

--- a/runtime/cpp/test/emboss_constant_view_test.cc
+++ b/runtime/cpp/test/emboss_constant_view_test.cc
@@ -22,7 +22,9 @@ namespace test {
 
 TEST(MaybeConstantViewTest, Read) {
   EXPECT_EQ(7, MaybeConstantView</**/ ::std::uint8_t>(7).Read());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(MaybeConstantView</**/ ::std::uint8_t>().Read(), "Known\\(\\)");
+#endif // EMBOSS_CHECK_ABORTS
 }
 
 TEST(MaybeConstantViewTest, UncheckedRead) {

--- a/runtime/cpp/test/emboss_defines_test.cc
+++ b/runtime/cpp/test/emboss_defines_test.cc
@@ -22,22 +22,24 @@ namespace emboss {
 namespace support {
 namespace test {
 
+#if EMBOSS_CHECK_ABORTS
 TEST(CheckPointerAlignment, Aligned) {
   ::std::uint32_t t;
-  EMBOSS_DCHECK_POINTER_ALIGNMENT(&t, sizeof t, 0);
-  EMBOSS_DCHECK_POINTER_ALIGNMENT(&t, 1, 0);
-  EMBOSS_DCHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1, sizeof t,
-                                  1);
-  EMBOSS_DCHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1, 1, 0);
+  EMBOSS_CHECK_POINTER_ALIGNMENT(&t, sizeof t, 0);
+  EMBOSS_CHECK_POINTER_ALIGNMENT(&t, 1, 0);
+  EMBOSS_CHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1, sizeof t, 1);
+  EMBOSS_CHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1, 1, 0);
 }
 
 TEST(CheckPointerAlignment, Misaligned) {
   ::std::uint32_t t;
-  EXPECT_DEATH(EMBOSS_DCHECK_POINTER_ALIGNMENT(&t, sizeof t, 1), "");
-  EXPECT_DEATH(EMBOSS_DCHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1,
-                                               sizeof t, 0),
+  EXPECT_DEATH(EMBOSS_CHECK_POINTER_ALIGNMENT(&t, sizeof t, 1), "");
+  EXPECT_DEATH(EMBOSS_CHECK_POINTER_ALIGNMENT(reinterpret_cast<char *>(&t) + 1,
+                                              sizeof t, 0),
                "");
+  (void)t;
 }
+#endif  // EMBOSS_CHECK_ABORTS
 
 #if EMBOSS_SYSTEM_IS_TWOS_COMPLEMENT
 TEST(SystemIsTwosComplement, CastToSigned) {

--- a/runtime/cpp/test/emboss_enum_view_test.cc
+++ b/runtime/cpp/test/emboss_enum_view_test.cc
@@ -182,9 +182,11 @@ TEST(EnumView, ReadAndWriteWithInsufficientBuffer) {
   ::std::vector</**/ ::std::uint8_t> bytes = {
       {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08}};
   auto enum64_view = FooViewN<64>{ReadWriteContiguousBuffer{bytes.data(), 4}};
-  EXPECT_DEATH(enum64_view.Read(), "");
   EXPECT_EQ(Foo::kReallyBig, enum64_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(enum64_view.Read(), "");
   EXPECT_DEATH(enum64_view.Write(Foo::kReallyBigBackwards), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_FALSE(enum64_view.TryToWrite(Foo::kReallyBigBackwards));
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x10, 0x0f, 0x0e, 0x0d, 0x0c,
                                                 0x0b, 0x0a, 0x09, 0x08}),
@@ -205,7 +207,9 @@ TEST(EnumView, NonPowerOfTwoSize) {
   enum24_view.Write(Foo::kBigBackwards);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x0e, 0x0f, 0x10, 0x0d}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(enum24_view.Write(Foo::k2to24), "");
+#endif  // EMBOSS_CHECK_ABORTS
   enum24_view.UncheckedWrite(Foo::k2to24);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x00, 0x00, 0x00, 0x0d}),
             bytes);
@@ -216,9 +220,11 @@ TEST(EnumView, NonPowerOfTwoSize) {
 TEST(EnumView, NonPowerOfTwoSizeInsufficientBuffer) {
   ::std::vector</**/ ::std::uint8_t> bytes = {{0x10, 0x0f, 0x0e, 0x0d}};
   auto enum24_view = FooViewN<24>{ReadWriteContiguousBuffer{bytes.data(), 2}};
-  EXPECT_DEATH(enum24_view.Read(), "");
   EXPECT_EQ(Foo::kBig, enum24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(enum24_view.Read(), "");
   EXPECT_DEATH(enum24_view.Write(Foo::kBigBackwards), "");
+#endif  // EMBOSS_CHECK_ABORTS
   enum24_view.UncheckedWrite(Foo::kBigBackwards);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x0e, 0x0f, 0x10, 0x0d}),
             bytes);

--- a/runtime/cpp/test/emboss_maybe_test.cc
+++ b/runtime/cpp/test/emboss_maybe_test.cc
@@ -46,7 +46,9 @@ TEST(Maybe, Unknown) {
   EXPECT_EQ(3, Maybe<int>().ValueOr(3));
   EXPECT_EQ(0, Maybe<int>().ValueOrDefault());
   EXPECT_FALSE(Maybe<bool>().ValueOrDefault());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(Maybe<int>().Value(), "Known()");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_FALSE(Maybe<bool>().ValueOrDefault());
   EXPECT_EQ(static_cast<Foo>(0), Maybe<Foo>().ValueOrDefault());
 

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -334,7 +334,9 @@ TEST(ReadOnlyContiguousBuffer, Methods) {
       {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05,
        0x04, 0x03, 0x02, 0x01}};
   const auto buffer = ReadOnlyContiguousBuffer{bytes.data(), bytes.size() - 4};
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(buffer.ReadBigEndianUInt<64>(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_TRUE(buffer.Ok());
   EXPECT_EQ(bytes.size() - 4, buffer.SizeInBytes());
   EXPECT_EQ(0x100f0e0d0c0b0a09UL, buffer.UncheckedReadBigEndianUInt<64>());
@@ -357,14 +359,18 @@ TEST(ReadOnlyContiguousBuffer, Methods) {
   EXPECT_FALSE(ReadOnlyContiguousBuffer().Ok());
   EXPECT_FALSE(
       (ReadOnlyContiguousBuffer{static_cast<char *>(nullptr), 12}.Ok()));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH((ReadOnlyContiguousBuffer{static_cast<char *>(nullptr), 4}
                     .ReadBigEndianUInt<32>()),
                "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0U, ReadOnlyContiguousBuffer().SizeInBytes());
   EXPECT_EQ(0U, (ReadOnlyContiguousBuffer{static_cast<char *>(nullptr), 12}
                      .SizeInBytes()));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(
       (ReadOnlyContiguousBuffer{bytes.data(), 0}.ReadBigEndianUInt<8>()), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   // The size of the resulting buffer should be the minimum of the available
   // size and the requested size.
@@ -419,6 +425,7 @@ TEST(ReadWriteContiguousBuffer, Methods) {
                                           0x06, 0x05, 0x04, 0x03, 0x02, 0x01}),
       bytes);
 
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(ReadWriteContiguousBuffer().ReadLittleEndianUInt<8>(), "");
   EXPECT_DEATH(
       (ReadWriteContiguousBuffer{static_cast<unsigned char *>(nullptr), 1}
@@ -428,6 +435,7 @@ TEST(ReadWriteContiguousBuffer, Methods) {
       (ReadWriteContiguousBuffer{static_cast<unsigned char *>(nullptr), 1}
            .WriteLittleEndianUInt<8>(0xff)),
       "");
+#endif  // EMBOSS_CHECK_ABORTS
 }
 
 TEST(ContiguousBuffer, AssignmentFromCompatibleContiguousBuffers) {
@@ -467,7 +475,9 @@ TEST(LittleEndianByteOrderer, Methods) {
   EXPECT_TRUE(buffer.Ok());
   EXPECT_EQ(0x0807060504030201UL, buffer.ReadUInt<64>());
   EXPECT_EQ(0x0807060504030201UL, buffer.UncheckedReadUInt<64>());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(buffer.ReadUInt<56>(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x07060504030201UL, buffer.UncheckedReadUInt<56>());
   buffer.WriteUInt<64>(0x0102030405060708);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{21, 22, 8, 7, 6, 5, 4, 3, 2, 1,
@@ -477,7 +487,9 @@ TEST(LittleEndianByteOrderer, Methods) {
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{21, 22, 1, 2, 3, 4, 5, 6, 7, 8,
                                                 23, 24}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(buffer.WriteUInt<56>(0x77777777777777), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   EXPECT_FALSE(LittleEndianByteOrderer<ReadOnlyContiguousBuffer>().Ok());
   EXPECT_EQ(0U,
@@ -500,7 +512,9 @@ TEST(BigEndianByteOrderer, Methods) {
   EXPECT_TRUE(buffer.Ok());
   EXPECT_EQ(0x0102030405060708UL, buffer.ReadUInt<64>());
   EXPECT_EQ(0x0102030405060708UL, buffer.UncheckedReadUInt<64>());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(buffer.ReadUInt<56>(), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(0x01020304050607UL, buffer.UncheckedReadUInt<56>());
   buffer.WriteUInt<64>(0x0807060504030201);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{21, 22, 8, 7, 6, 5, 4, 3, 2, 1,
@@ -510,7 +524,9 @@ TEST(BigEndianByteOrderer, Methods) {
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{21, 22, 1, 2, 3, 4, 5, 6, 7, 8,
                                                 23, 24}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(buffer.WriteUInt<56>(0x77777777777777), "");
+#endif  // EMBOSS_CHECK_ABORTS
 
   EXPECT_FALSE(BigEndianByteOrderer<ReadOnlyContiguousBuffer>().Ok());
   EXPECT_EQ(0U, BigEndianByteOrderer<ReadOnlyContiguousBuffer>().SizeInBytes());
@@ -539,6 +555,7 @@ TEST(NullByteOrderer, Methods) {
 
   EXPECT_FALSE(NullByteOrderer<ReadOnlyContiguousBuffer>().Ok());
   EXPECT_EQ(0U, NullByteOrderer<ReadOnlyContiguousBuffer>().SizeInBytes());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH((NullByteOrderer<ReadOnlyContiguousBuffer>{
                    ReadOnlyContiguousBuffer{bytes, 0}}
                     .ReadUInt<8>()),
@@ -547,6 +564,7 @@ TEST(NullByteOrderer, Methods) {
                    ReadOnlyContiguousBuffer{bytes, 2}}
                     .ReadUInt<8>()),
                "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_EQ(bytes[0], (NullByteOrderer<ReadOnlyContiguousBuffer>{
                           ReadOnlyContiguousBuffer{bytes, 0}}
                            .UncheckedReadUInt<8>()));
@@ -623,7 +641,9 @@ TEST(OffsetBitBlock, Methods) {
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x10, 0x0f, 0x0e, 0x0d, 0x0c,
                                                 0x0b, 0x0a, 0x09}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(offset_block.WriteUInt(0x10f0e0d0c0b0a), "");
+#endif  // EMBOSS_CHECK_ABORTS
   offset_block.UncheckedWriteUInt(0x10f0e0d0c0b0a);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x10, 0x0a, 0x0b, 0x0c, 0x0d,
                                                 0x0e, 0x0f, 0x09}),
@@ -641,7 +661,9 @@ TEST(OffsetBitBlock, Methods) {
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x10, 0x0a, 0x0b, 0x0c, 0x0d,
                                                 0x0e, 0x0f, 0x09}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(offset_offset_block.WriteUInt(0x10c0d), "");
+#endif  // EMBOSS_CHECK_ABORTS
   offset_offset_block.UncheckedWriteUInt(0x20c0d);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{0x10, 0x0a, 0x0b, 0x0d, 0x0c,
                                                 0x0e, 0x0f, 0x09}),

--- a/runtime/cpp/test/emboss_prelude_test.cc
+++ b/runtime/cpp/test/emboss_prelude_test.cc
@@ -218,9 +218,11 @@ TEST(UIntView, ReadAndWriteWithInsufficientBuffer) {
       {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08}};
   auto uint64_view =
       UIntViewN<64>{BitBlockN<64>{ReadWriteContiguousBuffer{bytes.data(), 4}}};
-  EXPECT_DEATH(uint64_view.Read(), "");
   EXPECT_EQ(0x090a0b0c0d0e0f10UL, uint64_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(uint64_view.Read(), "");
   EXPECT_DEATH(uint64_view.Write(0x100f0e0d0c0b0a09UL), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_FALSE(uint64_view.TryToWrite(0x100f0e0d0c0b0a09UL));
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{
                 {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08}}),
@@ -240,7 +242,9 @@ TEST(UIntView, NonPowerOfTwoSize) {
       UIntViewN<24>{BitBlockN<24>{ReadWriteContiguousBuffer{bytes.data(), 3}}};
   EXPECT_EQ(0x0e0f10U, uint24_view.Read());
   EXPECT_EQ(0x0e0f10U, uint24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(uint24_view.Write(0x1000000), "");
+#endif  // EMBOSS_CHECK_ABORTS
   uint24_view.Write(0x100f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0x10, 0x0d}}),
             bytes);
@@ -255,9 +259,11 @@ TEST(UIntView, NonPowerOfTwoSizeInsufficientBuffer) {
   ::std::vector</**/ ::std::uint8_t> bytes = {{0x10, 0x0f, 0x0e, 0x0d}};
   auto uint24_view =
       UIntViewN<24>{BitBlockN<24>{ReadWriteContiguousBuffer{bytes.data(), 2}}};
-  EXPECT_DEATH(uint24_view.Read(), "");
   EXPECT_EQ(0x0e0f10U, uint24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(uint24_view.Read(), "");
   EXPECT_DEATH(uint24_view.Write(0x100f0e), "");
+#endif  // EMBOSS_CHECK_ABORTS
   uint24_view.UncheckedWrite(0x100f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0x10, 0x0d}}),
             bytes);
@@ -278,7 +284,9 @@ TEST(UIntView, NonByteSize) {
   EXPECT_FALSE(uint23_view.CouldWriteValue(0x800f0e));
   EXPECT_FALSE(uint23_view.CouldWriteValue(0x800000));
   EXPECT_TRUE(uint23_view.CouldWriteValue(0x7fffff));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(uint23_view.Write(0x800f0e), "");
+#endif  // EMBOSS_CHECK_ABORTS
   uint23_view.Write(0x400f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0xc0, 0x80}}),
             bytes);
@@ -407,9 +415,11 @@ TEST(IntView, ReadAndWriteWithInsufficientBuffer) {
       {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08}};
   auto int64_view =
       IntViewN<64>{BitBlockN<64>{ReadWriteContiguousBuffer{bytes.data(), 4}}};
-  EXPECT_DEATH(int64_view.Read(), "");
   EXPECT_EQ(0x090a0b0c0d0e0f10L, int64_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(int64_view.Read(), "");
   EXPECT_DEATH(int64_view.Write(0x100f0e0d0c0b0a09L), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_FALSE(int64_view.TryToWrite(0x100f0e0d0c0b0a09L));
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{
                 {0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08}}),
@@ -428,14 +438,18 @@ TEST(IntView, NonPowerOfTwoSize) {
       IntViewN<24>{BitBlockN<24>{ReadWriteContiguousBuffer{bytes.data(), 3}}};
   EXPECT_EQ(0x0e0f10, int24_view.Read());
   EXPECT_EQ(0x0e0f10, int24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(int24_view.Write(0x1000000), "");
+#endif  // EMBOSS_CHECK_ABORTS
   int24_view.Write(0x100f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0x10, 0x0d}}),
             bytes);
   int24_view.Write(-0x100f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0xf2, 0xf0, 0xef, 0x0d}}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(int24_view.Write(0x1000000), "");
+#endif  // EMBOSS_CHECK_ABORTS
   int24_view.UncheckedWrite(0x1000000);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x00, 0x00, 0x00, 0x0d}}),
             bytes);
@@ -447,9 +461,11 @@ TEST(IntView, NonPowerOfTwoSizeInsufficientBuffer) {
   ::std::vector</**/ ::std::uint8_t> bytes = {{0x10, 0x0f, 0x0e, 0x0d}};
   auto int24_view =
       IntViewN<24>{BitBlockN<24>{ReadWriteContiguousBuffer{bytes.data(), 2}}};
-  EXPECT_DEATH(int24_view.Read(), "");
   EXPECT_EQ(0x0e0f10, int24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(int24_view.Read(), "");
   EXPECT_DEATH(int24_view.Write(0x100f0e), "");
+#endif  // EMBOSS_CHECK_ABORTS
   int24_view.UncheckedWrite(0x100f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0x10, 0x0d}}),
             bytes);
@@ -468,7 +484,9 @@ TEST(IntView, NonByteSize) {
                                     3}}.GetOffsetStorage<1, 0>(0, 23)};
   EXPECT_EQ(0x0, int23_view.Read());
   EXPECT_FALSE(int23_view.CouldWriteValue(0x400f0e));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(int23_view.Write(0x400f0e), "");
+#endif  // EMBOSS_CHECK_ABORTS
   int23_view.Write(0x200f0e);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x0e, 0x0f, 0xa0, 0x80}}),
             bytes);
@@ -493,7 +511,9 @@ TEST(IntView, OneBit) {
   EXPECT_FALSE(int1_view.CouldWriteValue(1));
   EXPECT_TRUE(int1_view.CouldWriteValue(0));
   EXPECT_TRUE(int1_view.CouldWriteValue(-1));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(int1_view.Write(1), "");
+#endif  // EMBOSS_CHECK_ABORTS
   int1_view.Write(-1);
   EXPECT_EQ(0xff, bytes[0]);
   EXPECT_EQ(-1, int1_view.Read());
@@ -669,9 +689,11 @@ TEST(BcdView, ReadAndWriteWithInsufficientBuffer) {
       {0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08}};
   auto bcd64_view =
       BcdViewN<64>{BitBlockN<64>{ReadWriteContiguousBuffer{bytes.data(), 4}}};
-  EXPECT_DEATH(bcd64_view.Read(), "");
   EXPECT_EQ(910111213141516UL, bcd64_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(bcd64_view.Read(), "");
   EXPECT_DEATH(bcd64_view.Write(1615141312111009), "");
+#endif  // EMBOSS_CHECK_ABORTS
   EXPECT_FALSE(bcd64_view.TryToWrite(1615141312111009));
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{
                 {0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x09, 0x08}}),
@@ -693,7 +715,9 @@ TEST(BcdView, NonPowerOfTwoSize) {
   bcd24_view.Write(161514);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x14, 0x15, 0x16, 0x13}}),
             bytes);
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(bcd24_view.Write(1000000), "");
+#endif  // EMBOSS_CHECK_ABORTS
   bcd24_view.UncheckedWrite(1000000);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x00, 0x00, 0x00, 0x13}}),
             bytes);
@@ -708,9 +732,11 @@ TEST(BcdView, NonPowerOfTwoSizeInsufficientBuffer) {
   ::std::vector</**/ ::std::uint8_t> bytes = {{0x16, 0x15, 0x14, 0x13}};
   auto bcd24_view =
       BcdViewN<24>{BitBlockN<24>{ReadWriteContiguousBuffer{bytes.data(), 2}}};
-  EXPECT_DEATH(bcd24_view.Read(), "");
   EXPECT_EQ(141516U, bcd24_view.UncheckedRead());
+#if EMBOSS_CHECK_ABORTS
+  EXPECT_DEATH(bcd24_view.Read(), "");
   EXPECT_DEATH(bcd24_view.Write(161514), "");
+#endif  // EMBOSS_CHECK_ABORTS
   bcd24_view.UncheckedWrite(161514);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x14, 0x15, 0x16, 0x13}}),
             bytes);
@@ -730,7 +756,9 @@ TEST(BcdView, NonByteSize) {
   EXPECT_EQ(0x0U, bcd23_view.Read());
   EXPECT_FALSE(bcd23_view.CouldWriteValue(800000));
   EXPECT_TRUE(bcd23_view.CouldWriteValue(799999));
+#if EMBOSS_CHECK_ABORTS
   EXPECT_DEATH(bcd23_view.Write(800000), "");
+#endif  // EMBOSS_CHECK_ABORTS
   bcd23_view.Write(432198);
   EXPECT_EQ((::std::vector</**/ ::std::uint8_t>{{0x98, 0x21, 0xc3, 0x80}}),
             bytes);


### PR DESCRIPTION
Move all side-effectful operations outside of EMBOSS_CHECK and related macros.

Add EMBOSS_CHECK_ABORTS and EMBOSS_DCHECK_ABORTS macros, so that tests can enable/disable EXPECT_DEATH.