### PR TITLE
Implement simple common subexpression elimination.

### DIFF
--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -313,3 +313,12 @@ emboss_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+emboss_cc_test(
+    name = "complex_offset_test",
+    srcs = ["testcode/complex_offset_test.cc"],
+    deps = [
+        "//testdata:complex_offset_emboss",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -468,16 +468,24 @@ inline typename $_type_reader_$ Generic$_parent_type_$View<Storage>::$_name_$()
   // call those methods at all.  Similarly, if the end of the field would come
   // before the start, we provide a null storage, though arguably we should
   // not.
-  if ($_parameters_known_$ has_$_name_$().ValueOr(false) && $_size_$.Known() &&
-      $_size_$.ValueOr(0) >= 0 && $_offset_$.Known() &&
-      $_offset_$.ValueOr(0) >= 0) {
-    return $_type_reader_$(
-        $_parameter_values_$ backing_
-            .template GetOffsetStorage<$_alignment_$, $_static_offset_$>(
-                $_offset_$.ValueOrDefault(), $_size_$.ValueOrDefault()));
-  } else {
-    return $_type_reader_$();
+$_parameter_subexpressions_$
+  if ($_parameters_known_$ has_$_name_$().ValueOr(false)) {
+$_size_and_offset_subexpressions_$
+    auto emboss_reserved_local_size = $_size_$;
+    auto emboss_reserved_local_offset = $_offset_$;
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+        return $_type_reader_$(
+                $_parameter_values_$ backing_
+                        .template GetOffsetStorage<$_alignment_$,
+                                                   $_static_offset_$>(
+                                emboss_reserved_local_offset.ValueOrDefault(),
+                                emboss_reserved_local_size.ValueOrDefault()));
+    }
   }
+  return $_type_reader_$();
 }
 
 template <class Storage>
@@ -617,6 +625,7 @@ $_write_methods_$
 
    private:
     ::emboss::support::Maybe</**/ $_logical_type_$> MaybeRead() const {
+$_read_subexpressions_$
       return $_read_value_$;
     }
 

--- a/compiler/back_end/cpp/testcode/complex_offset_test.cc
+++ b/compiler/back_end/cpp/testcode/complex_offset_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Tests of generated code for text format.
+// Tests of packed field support.
 #include <stdint.h>
 
 #include <type_traits>
@@ -30,17 +30,7 @@ TEST(PackedFields, PerformanceOfOk) {
   ::std::array<char, 64> values = {0};
   const auto view = MakePackedFieldsView(&values);
   EXPECT_TRUE(view.Ok());
-  EXPECT_TRUE(view.length1().Ok());
-  EXPECT_TRUE(view.length2().Ok());
-  EXPECT_TRUE(view.length3().Ok());
-  EXPECT_TRUE(view.length4().Ok());
-  EXPECT_TRUE(view.length5().Ok());
   EXPECT_TRUE(view.length6().Ok());
-  EXPECT_TRUE(view.data1().Ok());
-  EXPECT_TRUE(view.data2().Ok());
-  EXPECT_TRUE(view.data3().Ok());
-  EXPECT_TRUE(view.data4().Ok());
-  EXPECT_TRUE(view.data5().Ok());
   EXPECT_TRUE(view.data6().Ok());
 }
 

--- a/compiler/back_end/cpp/testcode/complex_offset_test.cc
+++ b/compiler/back_end/cpp/testcode/complex_offset_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests of generated code for text format.
+#include <stdint.h>
+
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "testdata/complex_offset.emb.h"
+
+namespace emboss {
+namespace test {
+namespace {
+
+TEST(PackedFields, PerformanceOfOk) {
+  ::std::array<char, 64> values = {0};
+  const auto view = MakePackedFieldsView(&values);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_TRUE(view.length1().Ok());
+  EXPECT_TRUE(view.length2().Ok());
+  EXPECT_TRUE(view.length3().Ok());
+  EXPECT_TRUE(view.length4().Ok());
+  EXPECT_TRUE(view.length5().Ok());
+  EXPECT_TRUE(view.length6().Ok());
+  EXPECT_TRUE(view.data1().Ok());
+  EXPECT_TRUE(view.data2().Ok());
+  EXPECT_TRUE(view.data3().Ok());
+  EXPECT_TRUE(view.data4().Ok());
+  EXPECT_TRUE(view.data5().Ok());
+  EXPECT_TRUE(view.data6().Ok());
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace emboss

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -284,3 +284,10 @@ emboss_cc_library(
         "virtual_field.emb",
     ],
 )
+
+emboss_cc_library(
+    name = "complex_offset_emboss",
+    srcs = [
+        "complex_offset.emb",
+    ],
+)

--- a/testdata/complex_offset.emb
+++ b/testdata/complex_offset.emb
@@ -1,0 +1,34 @@
+-- Test .emb with a struct with several consecutive packed fields.
+--
+-- This particular case stresses generated code; common subexpression
+-- elimination is needed in the code generator or else the generated code is
+-- very, *very* slow when compiled without optimizations.
+
+[$default byte_order: "BigEndian"]
+[(cpp) namespace: "emboss::test"]
+
+struct Length:
+  0 [+1]  UInt  length
+
+struct Data:
+  0 [+1]              Length    length
+  1 [+length.length]  UInt:8[]  data
+
+struct PackedFields:
+  0  [+1]            Length    length1 (l1)
+  0  [+l1.length+1]  Data      data1 (d1)
+  let o1 = d1.$size_in_bytes
+  o1 [+1]            Length    length2 (l2)
+  o1 [+l2.length+1]  Data      data2 (d2)
+  let o2 = o1 + d2.$size_in_bytes
+  o2 [+1]            Length    length3 (l3)
+  o2 [+l3.length+1]  Data      data3 (d3)
+  let o3 = o2 + d3.$size_in_bytes
+  o3 [+1]            Length    length4 (l4)
+  o3 [+l4.length+1]  Data      data4 (d4)
+  let o4 = o3 + d4.$size_in_bytes
+  o4 [+1]            Length    length5 (l5)
+  o4 [+l5.length+1]  Data      data5 (d5)
+  let o5 = o4 + d5.$size_in_bytes
+  o5 [+1]            Length    length6 (l6)
+  o5 [+l6.length+1]  Data      data6 (d6)


### PR DESCRIPTION
This change adds somewhat naive common subexpression elimination in a few places in the generated C++ code.  This has little or no effect when C++ compiler optimizations are enabled, however, some users expect to be able to run some code (e.g., tests) with C++ optimizations disabled.

With this change, certain constructs are many orders of magnitude faster in unoptimized builds.  The included test (complex_offset_test.cc) goes from >300s (timing out under Bazel) to <1s runtime.

Note that this does not perform any inlining, and the CSE is fairly naive (text-based), so unoptimized builds may still do a lot of repeated work.  It also does not add CSE everywhere it could be added; only to places that are likely to have performance issues.  Users who care even slightly about performance are still advised to compile with optimizations.