### PR TITLE
Fix Emboss under C++14

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -248,13 +248,13 @@ using $_name_$Writer =
 
 template <class View>
 struct EmbossReservedInternalIsGeneric$_name_$View {
-  static constexpr bool value = false;
+  static constexpr const bool value = false;
 };
 
 template <class Storage>
 struct EmbossReservedInternalIsGeneric$_name_$View<
     Generic$_name_$View<Storage>> {
-  static constexpr bool value = true;
+  static constexpr const bool value = true;
 };
 
 template <typename T>
@@ -523,7 +523,7 @@ Generic$_parent_type_$View<Storage>::has_$_name_$() const {
   };
 
   static constexpr $_virtual_view_type_name_$ $_name_$() {
-    return $_virtual_view_type_name_$();
+      return $_virtual_view_type_name_$();
   }
   static constexpr ::emboss::support::Maybe<bool> has_$_name_$() {
     return ::emboss::support::Maybe<bool>(true);
@@ -533,20 +533,20 @@ Generic$_parent_type_$View<Storage>::has_$_name_$() const {
 // ** structure_single_const_virtual_field_method_definitions ** ///////////////
 namespace $_parent_type_$ {
 inline constexpr $_logical_type_$ $_name_$() {
-  return $_read_value_$.ValueOrDefault();
+    return $_read_value_$.ValueOrDefault();
 }
 }  // namespace $_parent_type_$
 
-template <class Storage>
-inline constexpr $_logical_type_$
-Generic$_parent_type_$View<Storage>::$_virtual_view_type_name_$::Read() {
-  return $_parent_type_$::$_name_$();
+template<class Storage>
+inline constexpr $_logical_type_$ Generic$_parent_type_$View<
+        Storage>::$_virtual_view_type_name_$::Read() {
+    return $_parent_type_$::$_name_$();
 }
 
-template <class Storage>
+template<class Storage>
 inline constexpr $_logical_type_$ Generic$_parent_type_$View<
-    Storage>::$_virtual_view_type_name_$::UncheckedRead() {
-  return $_parent_type_$::$_name_$();
+        Storage>::$_virtual_view_type_name_$::UncheckedRead() {
+    return $_parent_type_$::$_name_$();
 }
 
 // ** structure_single_virtual_field_method_declarations ** ////////////////////
@@ -630,8 +630,8 @@ $_read_subexpressions_$
     }
 
     static constexpr bool ValueIsOk(
-        $_logical_type_$ emboss_reserved_local_value) {
-      return $_value_is_ok_$.ValueOr(false);
+            $_logical_type_$ emboss_reserved_local_value) {
+        return $_value_is_ok_$.ValueOr(false);
     }
 
     const Generic$_parent_type_$View view_;

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -523,7 +523,7 @@ Generic$_parent_type_$View<Storage>::has_$_name_$() const {
   };
 
   static constexpr $_virtual_view_type_name_$ $_name_$() {
-      return $_virtual_view_type_name_$();
+    return $_virtual_view_type_name_$();
   }
   static constexpr ::emboss::support::Maybe<bool> has_$_name_$() {
     return ::emboss::support::Maybe<bool>(true);
@@ -533,20 +533,21 @@ Generic$_parent_type_$View<Storage>::has_$_name_$() const {
 // ** structure_single_const_virtual_field_method_definitions ** ///////////////
 namespace $_parent_type_$ {
 inline constexpr $_logical_type_$ $_name_$() {
-    return $_read_value_$.ValueOrDefault();
+  return $_read_value_$.ValueOrDefault();
 }
 }  // namespace $_parent_type_$
 
-template<class Storage>
-inline constexpr $_logical_type_$ Generic$_parent_type_$View<
-        Storage>::$_virtual_view_type_name_$::Read() {
-    return $_parent_type_$::$_name_$();
+template <class Storage>
+inline constexpr $_logical_type_$
+Generic$_parent_type_$View<Storage>::$_virtual_view_type_name_$::Read() {
+  return $_parent_type_$::$_name_$();
 }
 
-template<class Storage>
-inline constexpr $_logical_type_$ Generic$_parent_type_$View<
-        Storage>::$_virtual_view_type_name_$::UncheckedRead() {
-    return $_parent_type_$::$_name_$();
+template <class Storage>
+inline constexpr $_logical_type_$
+Generic$_parent_type_$View<
+    Storage>::$_virtual_view_type_name_$::UncheckedRead() {
+  return $_parent_type_$::$_name_$();
 }
 
 // ** structure_single_virtual_field_method_declarations ** ////////////////////
@@ -630,8 +631,8 @@ $_read_subexpressions_$
     }
 
     static constexpr bool ValueIsOk(
-            $_logical_type_$ emboss_reserved_local_value) {
-        return $_value_is_ok_$.ValueOr(false);
+        $_logical_type_$ emboss_reserved_local_value) {
+      return $_value_is_ok_$.ValueOr(false);
     }
 
     const Generic$_parent_type_$View view_;

--- a/runtime/cpp/emboss_constant_view.h
+++ b/runtime/cpp/emboss_constant_view.h
@@ -39,7 +39,7 @@ class MaybeConstantView {
 
   constexpr ValueT Read() const { return value_.Value(); }
   constexpr ValueT UncheckedRead() const { return value_.ValueOrDefault(); }
-  constexpr bool Ok() { return value_.Known(); }
+  constexpr bool Ok() const { return value_.Known(); }
 
  private:
   ::emboss::support::Maybe<ValueT> value_;

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __cplusplus >= 201402L
+#if __cplusplus >= 201702L
 #include <string_view>
-#endif  // __cplusplus >= 201402L
+#endif  // __cplusplus >= 201702L
 #include <vector>
 
 #include "runtime/cpp/emboss_memory_util.h"
@@ -477,12 +477,12 @@ TEST(ContiguousBuffer, ToString) {
   auto str = buffer.ToString</**/ ::std::string>();
   EXPECT_TRUE((::std::is_same</**/ ::std::string, decltype(str)>::value));
   EXPECT_EQ(str, "abcd");
-#if __cplusplus >= 201402L
+#if __cplusplus >= 201702L
   auto str_view = buffer.ToString</**/ ::std::string_view>();
   EXPECT_TRUE(
       (::std::is_same</**/ ::std::string_view, decltype(str_view)>::value));
   EXPECT_EQ(str_view, "abcd");
-#endif  // __cplusplus >= 201402L
+#endif  // __cplusplus >= 201702L
 }
 
 TEST(LittleEndianByteOrderer, Methods) {

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __cplusplus >= 201702L
+#if __cplusplus >= 201703L
 #include <string_view>
-#endif  // __cplusplus >= 201702L
+#endif  // __cplusplus >= 201703L
 #include <vector>
 
 #include "runtime/cpp/emboss_memory_util.h"
@@ -477,12 +477,12 @@ TEST(ContiguousBuffer, ToString) {
   auto str = buffer.ToString</**/ ::std::string>();
   EXPECT_TRUE((::std::is_same</**/ ::std::string, decltype(str)>::value));
   EXPECT_EQ(str, "abcd");
-#if __cplusplus >= 201702L
+#if __cplusplus >= 201703L
   auto str_view = buffer.ToString</**/ ::std::string_view>();
   EXPECT_TRUE(
       (::std::is_same</**/ ::std::string_view, decltype(str_view)>::value));
   EXPECT_EQ(str_view, "abcd");
-#endif  // __cplusplus >= 201702L
+#endif  // __cplusplus >= 201703L
 }
 
 TEST(LittleEndianByteOrderer, Methods) {


### PR DESCRIPTION
constexpr non-static methods -> constexpr const non-static methods

Hide string_view behind C++17 check, not C++14.