### PR TITLE
Add a new option to allow partial text output for non-Ok() messages.

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -225,6 +225,8 @@ $_write_fields_$
     }
   }
 
+  static constexpr bool IsAggregate() { return true; }
+
 $_field_method_declarations_$
 
  private:
@@ -305,40 +307,61 @@ MakeAligned$_name_$View(
         continue;
       }
 
-
 // ** write_field_to_text_stream ** ////////////////////////////////////////////
     if (has_$_field_name_$().ValueOr(false)) {
-      if (emboss_reserved_local_field_options.multiline()) {
-        emboss_reserved_local_stream->Write(
-            emboss_reserved_local_field_options.current_indent());
-      } else {
-        if (emboss_reserved_local_wrote_field) {
-          emboss_reserved_local_stream->Write(",");
+      // Don't try to read the field if `allow_partial_output` is set and the
+      // field can't be `Read()`.  Aggregates should still be visited, even if
+      // they are not `Ok()` overall, since submembers may still be `Ok()`.
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          $_field_name_$().IsAggregate() || $_field_name_$().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
         }
-        emboss_reserved_local_stream->Write(" ");
-      }
-      emboss_reserved_local_stream->Write("$_field_name_$: ");
-      $_field_name_$().WriteToTextStream(emboss_reserved_local_stream,
-                                         emboss_reserved_local_field_options);
-      emboss_reserved_local_wrote_field = true;
-      if (emboss_reserved_local_field_options.multiline()) {
-        emboss_reserved_local_stream->Write("\n");
+        emboss_reserved_local_stream->Write("$_field_name_$: ");
+        $_field_name_$().WriteToTextStream(emboss_reserved_local_stream,
+                                           emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !$_field_name_$().IsAggregate() && !$_field_name_$().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# $_field_name_$: UNREADABLE\n");
       }
     }
-
 
 // ** write_read_only_field_to_text_stream ** //////////////////////////////////
     if (has_$_field_name_$().ValueOr(false) &&
         emboss_reserved_local_field_options.comments()) {
-      emboss_reserved_local_stream->Write(
-          emboss_reserved_local_field_options.current_indent());
-      // TODO(bolms): When there are multiline read-only fields, add an option
-      // to TextOutputOptions to add `# ` to the current indent and use it here,
-      // so that subsequent lines are also commented out.
-      emboss_reserved_local_stream->Write("# $_field_name_$: ");
-      $_field_name_$().WriteToTextStream(emboss_reserved_local_stream,
-                                         emboss_reserved_local_field_options);
-      emboss_reserved_local_stream->Write("\n");
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          $_field_name_$().IsAggregate() || $_field_name_$().Ok()) {
+        emboss_reserved_local_stream->Write(
+            emboss_reserved_local_field_options.current_indent());
+        // TODO(bolms): When there are multiline read-only fields, add an option
+        // to TextOutputOptions to add `# ` to the current indent and use it
+        // here, so that subsequent lines are also commented out.
+        emboss_reserved_local_stream->Write("# $_field_name_$: ");
+        $_field_name_$().WriteToTextStream(emboss_reserved_local_stream,
+                                           emboss_reserved_local_field_options);
+        emboss_reserved_local_stream->Write("\n");
+      } else {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# $_field_name_$: UNREADABLE\n");
+      }
     }
 
 // ** constant_structure_size_method ** ////////////////////////////////////////
@@ -520,6 +543,8 @@ Generic$_parent_type_$View<Storage>::has_$_name_$() const {
       ::emboss::support::$_write_to_text_stream_function_$(
           this, emboss_reserved_local_stream, emboss_reserved_local_options);
     }
+
+    static constexpr bool IsAggregate() { return false; }
   };
 
   static constexpr $_virtual_view_type_name_$ $_name_$() {
@@ -621,6 +646,8 @@ Generic$_parent_type_$View<
       ::emboss::support::$_write_to_text_stream_function_$(
           this, emboss_reserved_local_stream, emboss_reserved_local_options);
     }
+
+    static constexpr bool IsAggregate() { return false; }
 
 $_write_methods_$
 

--- a/doc/cpp-reference.md
+++ b/doc/cpp-reference.md
@@ -1902,7 +1902,9 @@ TextOutputOptions PlusOneIndent() const;
 `PlusOneIndent` returns a new `TextOutputOptions` with one more level of
 indentation than the current `TextOutputOptions`. This is primarily intended for
 use inside of `WriteToTextStream` methods, as a way to get an indented
-`TextOutputOptions` to pass to the `WriteToTextStream` methods of child objects.
+`TextOutputOptions` to pass to the `WriteToTextStream` methods of child
+objects.  However, application callers may use `PlusOneIndent()`, possibly
+multiple times, to indent the entire output.
 
 ### `Multiline` method
 
@@ -1950,10 +1952,19 @@ Returns a new `TextOutputOptions` with the same options as the current
 `TextOutputOptions`, except for a new value for `digit_grouping()`. The new
 numeric base should be 2, 10, or 16.
 
+### `WithAllowPartialOutput` method
+
+```c++
+TextOutputOptions WithAllowPartialOutput(bool new_value) const;
+```
+
+Returns a new `TextOutputOptions` with the same options as the current
+`TextOutputOptions`, except for a new value for `allow_partial_output()`.
+
 ### `current_indent` method
 
 ```c++
-::std::string current_indent() const;
+::std::string current_indent() const;  // Default "".
 ```
 
 Returns the current indent string.
@@ -1961,16 +1972,16 @@ Returns the current indent string.
 ### `indent` method
 
 ```c++
-::std::string indent() const;
+::std::string indent() const;  // Default "  ".
 ```
 
-Returns the indent string. The indent string is the string used for a single
-level of indentation; most callers will prefer `current_indent`.
+Returns the indent string.  The indent string is the string used for a *single*
+level of indentation.
 
 ### `multiline` method
 
 ```c++
-bool multiline() const;
+bool multiline() const;  // Default false.
 ```
 
 Returns `true` if text output should use multiple lines, or `false` if text
@@ -1979,7 +1990,7 @@ output should be single-line only.
 ### `digit_grouping` method
 
 ```c++
-bool digit_grouping() const;
+bool digit_grouping() const;  // Default false.
 ```
 
 Returns `true` if text output should include digit separators on numbers; i.e.
@@ -1988,7 +1999,7 @@ Returns `true` if text output should include digit separators on numbers; i.e.
 ### `comments` method
 
 ```c++
-bool comments() const;
+bool comments() const;  // Default false.
 ```
 
 Returns `true` if text output should include comments, e.g., to show numbers in
@@ -1997,8 +2008,25 @@ multiple bases.
 ### `numeric_base` method
 
 ```c++
-uint8_t numeric_base() const;
+uint8_t numeric_base() const;  // Default 10.
 ```
 
 Returns the numeric base that should be used for formatting numbers. This should
 always be 2, 10, or 16.
+
+### `allow_partial_output` method
+
+```c++
+bool allow_partial_output() const;  // Default false.
+```
+
+Returns `true` if text output should attempt to extract fields from a view that
+is not `Ok()`.  If so:
+
+*   `WriteToString()` or `WriteToTextStream()` should never `CHECK`-fail.
+*   Atomic fields (e.g., `Int`, `UInt`, `enum`, `Flag`, etc. types) will not be
+    written to the text stream if they cannot be read.
+*   If `comments()` is also `true`, unreadable atomic fields will be commented
+    in the text stream.
+*   Aggregate fields (`struct`, `bits`, or arrays) will be written, but may be
+    missing fields or entirely empty if they have non-`Ok()` members.

--- a/runtime/cpp/emboss_array_view.h
+++ b/runtime/cpp/emboss_array_view.h
@@ -248,6 +248,8 @@ class GenericArrayView final {
     WriteArrayToTextStream(this, stream, options);
   }
 
+  static constexpr bool IsAggregate() { return true; }
+
   BufferType BackingStorage() const { return buffer_; }
 
   // Forwards to BufferType's ToString(), if any, but only if ElementView is a

--- a/runtime/cpp/emboss_enum_view.h
+++ b/runtime/cpp/emboss_enum_view.h
@@ -151,6 +151,8 @@ class EnumView final {
     ::emboss::support::WriteEnumViewToTextStream(this, stream, options);
   }
 
+  static constexpr bool IsAggregate() { return false; }
+
   static constexpr int SizeInBits() { return Parameters::kBits; }
 
  private:

--- a/runtime/cpp/emboss_prelude.h
+++ b/runtime/cpp/emboss_prelude.h
@@ -118,6 +118,8 @@ class FlagView final {
     ::emboss::support::WriteBooleanViewToTextStream(this, stream, options);
   }
 
+  static constexpr bool IsAggregate() { return false; }
+
  private:
   BitBlock bit_block_;
 };
@@ -297,6 +299,8 @@ class UIntView final {
     support::WriteIntegerViewToTextStream(this, stream, options);
   }
 
+  static constexpr bool IsAggregate() { return false; }
+
   static constexpr int SizeInBits() { return Parameters::kBits; }
 
  private:
@@ -459,6 +463,8 @@ class IntView final {
                          ::emboss::TextOutputOptions options) const {
     support::WriteIntegerViewToTextStream(this, stream, options);
   }
+
+  static constexpr bool IsAggregate() { return false; }
 
   static constexpr int SizeInBits() { return Parameters::kBits; }
 
@@ -649,6 +655,8 @@ class BcdView final {
     support::WriteIntegerViewToTextStream(this, stream, options);
   }
 
+  static constexpr bool IsAggregate() { return false; }
+
   template <typename OtherView>
   void CopyFrom(const OtherView &other) const {
     Write(other.Read());
@@ -788,6 +796,8 @@ class FloatView final {
                          ::emboss::TextOutputOptions options) const {
     support::WriteFloatToTextStream(Read(), stream, options);
   }
+
+  static constexpr bool IsAggregate() { return false; }
 
   static constexpr int SizeInBits() { return Parameters::kBits; }
 

--- a/runtime/cpp/test/emboss_text_util_test.cc
+++ b/runtime/cpp/test/emboss_text_util_test.cc
@@ -420,6 +420,13 @@ TEST(TextOutputOptions, WithNumericBase) {
   EXPECT_EQ(2, new_options.numeric_base());
 }
 
+TEST(TextOutputOptions, WithAllowPartialOutput) {
+  TextOutputOptions options;
+  TextOutputOptions new_options = options.WithAllowPartialOutput(true);
+  EXPECT_FALSE(options.allow_partial_output());
+  EXPECT_TRUE(new_options.allow_partial_output());
+}
+
 // Small helper function for the various WriteIntegerToTextStream tests; just
 // sets up a stream, forwards its arguments to WriteIntegerToTextStream, and
 // then returns the text from the stream.

--- a/testdata/requires.emb
+++ b/testdata/requires.emb
@@ -85,3 +85,10 @@ struct RequiresWithOptionalFields:
     if b_exists:
       2 [+1]  Flag b_true
         [requires: this]
+
+
+struct RequiresInArrayElements:
+  struct Element:
+    0 [+1]  UInt:8  x  [requires: 0 <= this <= 10]
+
+  0 [+4]  Element[]  xs


### PR DESCRIPTION
Adds a new `WithAllowPartialOutput()` method to `TextOutputOptions` to
allow `WriteToString()` to write partial output when called with a
non-`Ok()` view.