### PR TITLE
Move generate_grammar_md to data deps in docs_are_up_to_date_test

### DIFF
--- a/compiler/front_end/BUILD
+++ b/compiler/front_end/BUILD
@@ -452,10 +452,9 @@ py_test(
     name = "docs_are_up_to_date_test",
     srcs = ["docs_are_up_to_date_test.py"],
     data = [
+        ":generate_grammar_md",
         "//doc:grammar_md",
     ],
     python_version = "PY3",
-    deps = [
-        ":generate_grammar_md",
-    ],
+    deps = [],
 )


### PR DESCRIPTION
generate_grammar_md is a py_binary and should be listed in data instead of deps.