### PR TITLE
Explicitly downcast in emboss_text_util.h

### DIFF
--- a/runtime/cpp/emboss_text_util.h
+++ b/runtime/cpp/emboss_text_util.h
@@ -69,7 +69,7 @@ class TextOutputOptions final {
 
   TextOutputOptions WithNumericBase(int new_value) const {
     TextOutputOptions result = *this;
-    result.numeric_base_ = static_cast<::std::uint8_t>(new_value);
+    result.numeric_base_ = static_cast</**/ ::std::uint8_t>(new_value);
     return result;
   }
 

--- a/runtime/cpp/emboss_text_util.h
+++ b/runtime/cpp/emboss_text_util.h
@@ -69,7 +69,7 @@ class TextOutputOptions final {
 
   TextOutputOptions WithNumericBase(int new_value) const {
     TextOutputOptions result = *this;
-    result.numeric_base_ = new_value;
+    result.numeric_base_ = static_cast<::std::uint8_t>(new_value);
     return result;
   }
 


### PR DESCRIPTION
The line in question generates a compilation failure in Fuchsia, "error: implicit conversion loses integer precision: int to ::std::uint8_t" due to the "-Wimplicit-int-conversion" diagnostic flag. Adding an explicit `static_cast` here allows compilation.