### PR TITLE
Fix uninitialized memory in test code.

### DIFF
--- a/compiler/back_end/cpp/testcode/uint_sizes_test.cc
+++ b/compiler/back_end/cpp/testcode/uint_sizes_test.cc
@@ -360,7 +360,7 @@ TEST(SizesView, CanReadExplicitlySizedEnumSizes) {
 }
 
 TEST(SizesWriter, CanWriteExplicitlySizedEnumSizes) {
-  ::std::uint8_t buffer[sizeof kExplicitlySizedEnumSizes];
+  ::std::uint8_t buffer[sizeof kExplicitlySizedEnumSizes] = {0};
   auto writer = ExplicitlySizedEnumSizesWriter(buffer, sizeof buffer);
   writer.one_byte().Write(ExplicitlySizedEnum::VALUE1);
   writer.two_byte().Write(ExplicitlySizedEnum::VALUE10);


### PR DESCRIPTION
The `CanWriteExplicitlySizedEnumSizes` test can fail on some
compilers/configurations due to `buffer` being uninitialized.

This change fixes that issue.