### PR TITLE
Create automatic releases via github workflow.

### DIFF
--- a/.github/scripts/set_release_version.py
+++ b/.github/scripts/set_release_version.py
@@ -1,0 +1,7 @@
+# Obtains a date-based version for the release workflow.
+
+import datetime
+
+now_utc = datetime.datetime.now(datetime.timezone.utc)
+version = now_utc.strftime('%Y.%m%d.%H%M%S')
+print('::set-output name=version::v{}'.format(version))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: Release
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@master
+        with:
+          python-version: '3.x'
+      - name: Set Release Version
+        id: set_release_version
+        run: python ./.github/scripts/set_release_version.py
+      - name: Create Archive Release
+        uses: thedoctor0/zip-release@master
+        with:
+          filename: 'emboss.zip'
+          exclusions: '*.git*'
+      - name: Automatic Release Upload
+        id: automatic_release
+        uses: 'marvinpinto/action-automatic-releases@latest'
+        with:
+          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          automatic_release_tag: ${{ steps.set_release_version.outputs.version }}
+          prerelease: false
+          title: ${{ steps.set_release_version.outputs.version }}
+          files: |
+            emboss.zip


### PR DESCRIPTION
Sets up a github workflow that will automatically push a release when the master branch is updated.

The release version is set by `set_release_version.py` and follows the format `YYYY.MMDD.HHMMSS`.

This release action doesn't do anything special at the moment except for creating a zipfile with the sources.  I plan to use this workflow as a basis for adding Arduino integration in the future.