### PR TITLE
Fix Python 3.11 inspect usage

### DIFF
--- a/compiler/util/traverse_ir.py
+++ b/compiler/util/traverse_ir.py
@@ -21,8 +21,8 @@ from compiler.util import ir_pb2
 
 def _call_with_optional_args(function, positional_arg, keyword_args):
   """Calls function with whatever keyword_args it will accept."""
-  argspec = inspect.getargspec(function)
-  if argspec.keywords:
+  argspec = inspect.getfullargspec(function)
+  if argspec.kwonlyargs:
     # If the function accepts a kwargs parameter, then it will accept all
     # arguments.
     # Note: this isn't technically true if one of the keyword arguments has the


### PR DESCRIPTION
inspect.getargspec is no longer available in Python 3.11. Here are the docs as of 3.10:
https://docs.python.org/3.10/library/inspect.html#inspect.getargspec

This switches to getfullargspec which is nearly a drop in replacement: https://docs.python.org/3.11/library/inspect.html#inspect.getfullargspec