### PR TITLE
Implement `enum_case` attribute in cpp backend

### DIFF
--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -35,12 +35,19 @@ py_binary(
 )
 
 py_library(
+    name = "attributes",
+    srcs = ["attributes.py"],
+    deps = []
+)
+
+py_library(
     name = "header_generator",
     srcs = ["header_generator.py"],
     data = [
         "generated_code_templates",
     ],
     deps = [
+        ":attributes",
         "//compiler/back_end/util:code_template",
         "//compiler/util:attribute_util",
         "//compiler/util:ir_pb2",
@@ -110,6 +117,17 @@ emboss_cc_test(
     ],
     deps = [
         "//testdata:enum_emboss",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+emboss_cc_test(
+    name = "enum_case_test",
+    srcs = [
+        "testcode/enum_case_test.cc",
+    ],
+    deps = [
+        "//testdata:enum_case_emboss",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/compiler/back_end/cpp/attributes.py
+++ b/compiler/back_end/cpp/attributes.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attributes in the C++ backend and associated metadata."""
+
+from enum import Enum
+from compiler.util import attribute_util
+
+
+class Attribute(str, Enum):
+    """Attributes available in the C++ backend."""
+    NAMESPACE = "namespace"
+    ENUM_CASE = "enum_case"
+
+
+# Types associated with C++ backend attributes.
+TYPES = {
+    Attribute.NAMESPACE: attribute_util.STRING,
+    Attribute.ENUM_CASE: attribute_util.STRING,
+}
+
+
+class Scope(set[tuple[Attribute, bool]], Enum):
+    """Allowed scopes for C++ backend attributes.
+
+    Each entry is a set of (Attribute, default?) tuples, the first value being
+    the attribute itself, the second value being a boolean value indicating
+    whether the attribute is allowed to be defaulted in that scope."""
+    BITS = {
+        # Bits may contain an enum definition.
+        (Attribute.ENUM_CASE, True)
+    }
+    ENUM = {
+        (Attribute.ENUM_CASE, True),
+    }
+    ENUM_VALUE = {
+        (Attribute.ENUM_CASE, False),
+    }
+    MODULE = {
+        (Attribute.NAMESPACE, False),
+        (Attribute.ENUM_CASE, True),
+    },
+    STRUCT = {
+        # Struct may contain an enum definition.
+        (Attribute.ENUM_CASE, True),
+    }

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -840,12 +840,12 @@ static inline ::std::ostream &operator<<(
 
 // ** enum_from_name_case ** ///////////////////////////////////////////////////
     if (!strcmp("$_name_$", emboss_reserved_local_name)) {
-      *emboss_reserved_local_result = $_enum_$::$_name_$;
+      *emboss_reserved_local_result = $_enum_$::$_value_$;
       return true;
     }
 
 // ** name_from_enum_case ** ///////////////////////////////////////////////////
-      case $_enum_$::$_name_$: return "$_name_$";
+      case $_enum_$::$_value_$: return "$_name_$";
 
 // ** enum_is_known_case ** ////////////////////////////////////////////////////
       case $_enum_$::$_name_$: return true;

--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -1256,8 +1256,8 @@ def _split_enum_case_values_into_spans(enum_case_value):
   # except that this yields spans within the string rather than the strings
   # themselves, and no span is yielded for a trailing comma.
   start, end = 0, len(enum_case_value)
-  while start < end:
-    # Find a ',' delimiter to split on.
+  while start <= end:
+    # Find a ',' delimiter to split on
     delimiter = enum_case_value.find(',', start, end)
     if delimiter < 0:
       delimiter = end
@@ -1266,16 +1266,16 @@ def _split_enum_case_values_into_spans(enum_case_value):
     substr_end = delimiter
 
     # Drop leading whitespace
-    while (enum_case_value[substr_start].isspace() and
-           substr_start < substr_end):
-        substr_start += 1
+    while (substr_start < substr_end and
+           enum_case_value[substr_start].isspace()):
+      substr_start += 1
     # Drop trailing whitespace
-    while (enum_case_value[substr_end - 1].isspace() and
-           substr_start < substr_end):
+    while (substr_start < substr_end and
+           enum_case_value[substr_end - 1].isspace()):
       substr_end -= 1
 
     # Skip a trailing comma
-    if substr_start == end:
+    if substr_start == end and start != 0:
       break
 
     yield substr_start, substr_end
@@ -1448,7 +1448,7 @@ def _verify_enum_case_attribute(attr, source_file_name, errors):
     if start == end:
       errors.append([error.error(
           source_file_name, case_source_location,
-          'Empty enum case (excess comma).')])
+          'Empty enum case (or excess comma).')])
       continue
 
     if case in seen_cases:

--- a/compiler/back_end/cpp/header_generator_test.py
+++ b/compiler/back_end/cpp/header_generator_test.py
@@ -179,7 +179,7 @@ class NormalizeIrTest(unittest.TestCase):
 
     self.assertEqual([[
         error.error("m.emb", bad_case_source_location,
-                    'Empty enum case (excess comma).')
+                    'Empty enum case (or excess comma).')
     ]], header_generator.generate_header(ir)[1])
 
     # Leading comma
@@ -193,7 +193,7 @@ class NormalizeIrTest(unittest.TestCase):
 
     self.assertEqual([[
         error.error("m.emb", bad_case_source_location,
-                    'Empty enum case (excess comma).')
+                    'Empty enum case (or excess comma).')
     ]], header_generator.generate_header(ir)[1])
 
     # Excess trailing comma
@@ -207,7 +207,7 @@ class NormalizeIrTest(unittest.TestCase):
 
     self.assertEqual([[
         error.error("m.emb", bad_case_source_location,
-                    'Empty enum case (excess comma).')
+                    'Empty enum case (or excess comma).')
     ]], header_generator.generate_header(ir)[1])
 
     # Whitespace enum case
@@ -221,7 +221,49 @@ class NormalizeIrTest(unittest.TestCase):
 
     self.assertEqual([[
         error.error("m.emb", bad_case_source_location,
-                    'Empty enum case (excess comma).')
+                    'Empty enum case (or excess comma).')
+    ]], header_generator.generate_header(ir)[1])
+
+    # Empty enum_case string
+    ir = _make_ir_from_emb('enum Foo:\n'
+                           '  [(cpp) $default enum_case: ""]\n'
+                           '  BAR = 1\n'
+                           '  BAZ = 2\n')
+
+    bad_case_source_location.start.column = 30
+    bad_case_source_location.end.column = 30
+
+    self.assertEqual([[
+        error.error("m.emb", bad_case_source_location,
+                    'Empty enum case (or excess comma).')
+    ]], header_generator.generate_header(ir)[1])
+
+    # Whitespace enum_case string
+    ir = _make_ir_from_emb('enum Foo:\n'
+                           '  [(cpp) $default enum_case: "     "]\n'
+                           '  BAR = 1\n'
+                           '  BAZ = 2\n')
+
+    bad_case_source_location.start.column = 35
+    bad_case_source_location.end.column = 35
+
+    self.assertEqual([[
+        error.error("m.emb", bad_case_source_location,
+                    'Empty enum case (or excess comma).')
+    ]], header_generator.generate_header(ir)[1])
+
+    # One-character whitespace enum_case string
+    ir = _make_ir_from_emb('enum Foo:\n'
+                           '  [(cpp) $default enum_case: " "]\n'
+                           '  BAR = 1\n'
+                           '  BAZ = 2\n')
+
+    bad_case_source_location.start.column = 31
+    bad_case_source_location.end.column = 31
+
+    self.assertEqual([[
+        error.error("m.emb", bad_case_source_location,
+                    'Empty enum case (or excess comma).')
     ]], header_generator.generate_header(ir)[1])
 
 

--- a/compiler/back_end/cpp/header_generator_test.py
+++ b/compiler/back_end/cpp/header_generator_test.py
@@ -173,7 +173,7 @@ class NormalizeIrTest(unittest.TestCase):
 
     bad_case_source_location = ir_pb2.Location()
     bad_case_source_location.CopyFrom(attr.value.source_location)
-    # Location excess comma.
+    # Location of excess comma.
     bad_case_source_location.start.column = 42
     bad_case_source_location.end.column = 42
 

--- a/compiler/back_end/cpp/testcode/enum_case_test.cc
+++ b/compiler/back_end/cpp/testcode/enum_case_test.cc
@@ -31,6 +31,15 @@ TEST(EnumShouty, AccessValuesByNameInSource) {
   EXPECT_EQ(static_cast<int>(EnumShouty::LONG_ENUM_VALUE_NAME), 8);
 }
 
+TEST(EnumShouty, EnumIsKnown) {
+  EXPECT_TRUE(EnumIsKnown(EnumShouty::FIRST));
+  EXPECT_TRUE(EnumIsKnown(EnumShouty::SECOND));
+  EXPECT_TRUE(EnumIsKnown(EnumShouty::TWO_WORD));
+  EXPECT_TRUE(EnumIsKnown(EnumShouty::THREE_WORD_ENUM));
+  EXPECT_TRUE(EnumIsKnown(EnumShouty::LONG_ENUM_VALUE_NAME));
+  EXPECT_FALSE(EnumIsKnown(static_cast<EnumShouty>(999)));
+}
+
 TEST(EnumShouty, NameToEnum) {
   EnumShouty result;
 
@@ -77,41 +86,52 @@ TEST(EnumDefault, AccessValuesByNameInSource) {
   EXPECT_EQ(static_cast<int>(EnumDefault::kLongEnumValueName), 8);
 }
 
+TEST(EnumDefault, EnumIsKnown) {
+  EXPECT_TRUE(EnumIsKnown(EnumDefault::kFirst));
+  EXPECT_TRUE(EnumIsKnown(EnumDefault::kSecond));
+  EXPECT_TRUE(EnumIsKnown(EnumDefault::kTwoWord));
+  EXPECT_TRUE(EnumIsKnown(EnumDefault::kThreeWordEnum));
+  EXPECT_TRUE(EnumIsKnown(EnumDefault::kLongEnumValueName));
+  EXPECT_FALSE(EnumIsKnown(static_cast<EnumDefault>(999)));
+}
+
 TEST(EnumDefault, NameToEnum) {
   EnumDefault result;
 
-  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
   EXPECT_EQ(EnumDefault::kFirst, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("SECOND", &result));
   EXPECT_EQ(EnumDefault::kSecond, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("TWO_WORD", &result));
   EXPECT_EQ(EnumDefault::kTwoWord, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
   EXPECT_EQ(EnumDefault::kThreeWordEnum, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
   EXPECT_EQ(EnumDefault::kLongEnumValueName, result);
 }
 
-TEST(EnumDefault, NameToEnumFailsWithShouty) {
+TEST(EnumDefault, NameToEnumFailsWithKCamel) {
   EnumDefault result = EnumDefault::kFirst;
 
-  EXPECT_FALSE(TryToGetEnumFromName("SECOND", &result));
+  EXPECT_FALSE(TryToGetEnumFromName("kFirst", &result));
   EXPECT_EQ(EnumDefault::kFirst, result);
-  EXPECT_FALSE(TryToGetEnumFromName("TWO_WORD", &result));
+  EXPECT_FALSE(TryToGetEnumFromName("kSecond", &result));
   EXPECT_EQ(EnumDefault::kFirst, result);
-  EXPECT_FALSE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
+  EXPECT_FALSE(TryToGetEnumFromName("kTwoWord", &result));
   EXPECT_EQ(EnumDefault::kFirst, result);
-  EXPECT_FALSE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
+  EXPECT_FALSE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kLongEnumValueName", &result));
   EXPECT_EQ(EnumDefault::kFirst, result);
 }
 
 TEST(EnumDefault, EnumToName) {
-  EXPECT_EQ("kFirst", TryToGetNameFromEnum(EnumDefault::kFirst));
-  EXPECT_EQ("kSecond", TryToGetNameFromEnum(EnumDefault::kSecond));
-  EXPECT_EQ("kTwoWord", TryToGetNameFromEnum(EnumDefault::kTwoWord));
-  EXPECT_EQ("kThreeWordEnum",
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumDefault::kFirst));
+  EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumDefault::kSecond));
+  EXPECT_EQ("TWO_WORD", TryToGetNameFromEnum(EnumDefault::kTwoWord));
+  EXPECT_EQ("THREE_WORD_ENUM",
     TryToGetNameFromEnum(EnumDefault::kThreeWordEnum));
-  EXPECT_EQ("kLongEnumValueName",
+  EXPECT_EQ("LONG_ENUM_VALUE_NAME",
     TryToGetNameFromEnum(EnumDefault::kLongEnumValueName));
 }
 
@@ -128,19 +148,22 @@ TEST(EnumShoutyAndKCamel, AccessValuesByNameInSource) {
   EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kLongEnumValueName), 8);
 }
 
+TEST(EnumShoutyAndKCamel, EnumIsKnown) {
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::FIRST));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::SECOND));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::TWO_WORD));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::THREE_WORD_ENUM));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::LONG_ENUM_VALUE_NAME));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::kFirst));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::kSecond));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::kTwoWord));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::kThreeWordEnum));
+  EXPECT_TRUE(EnumIsKnown(EnumShoutyAndKCamel::kLongEnumValueName));
+  EXPECT_FALSE(EnumIsKnown(static_cast<EnumShoutyAndKCamel>(999)));
+}
+
 TEST(EnumShoutyAndKCamel, NameToEnum) {
   EnumShoutyAndKCamel result;
-
-  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
-  EXPECT_EQ(EnumShoutyAndKCamel::kFirst, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kSecond", &result));
-  EXPECT_EQ(EnumShoutyAndKCamel::kSecond, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
-  EXPECT_EQ(EnumShoutyAndKCamel::kTwoWord, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
-  EXPECT_EQ(EnumShoutyAndKCamel::kThreeWordEnum, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
-  EXPECT_EQ(EnumShoutyAndKCamel::kLongEnumValueName, result);
 
   EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
   EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
@@ -152,6 +175,21 @@ TEST(EnumShoutyAndKCamel, NameToEnum) {
   EXPECT_EQ(EnumShoutyAndKCamel::THREE_WORD_ENUM, result);
   EXPECT_TRUE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
   EXPECT_EQ(EnumShoutyAndKCamel::LONG_ENUM_VALUE_NAME, result);
+}
+
+TEST(EnumShoutyAndKCamel, NameToEnumFailsWithKCamel) {
+  EnumShoutyAndKCamel result = EnumShoutyAndKCamel::FIRST;
+
+  EXPECT_FALSE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
 }
 
 TEST(EnumShoutyAndKCamel, EnumToName) {
@@ -172,46 +210,92 @@ TEST(EnumShoutyAndKCamel, EnumToName) {
     TryToGetNameFromEnum(EnumShoutyAndKCamel::kLongEnumValueName));
 }
 
+TEST(EnumMixed, AccessValuesByNameInSource) {
+  EXPECT_EQ(static_cast<int>(EnumMixed::FIRST), 0);
+  EXPECT_EQ(static_cast<int>(EnumMixed::kFirst), 0);
+  EXPECT_EQ(static_cast<int>(EnumMixed::SECOND), 1);
+  EXPECT_EQ(static_cast<int>(EnumMixed::kTwoWord), 2);
+  EXPECT_EQ(static_cast<int>(EnumMixed::THREE_WORD_ENUM), 4);
+  EXPECT_EQ(static_cast<int>(EnumMixed::kThreeWordEnum), 4);
+  EXPECT_EQ(static_cast<int>(EnumMixed::kLongEnumValueName), 8);
+}
+
+TEST(EnumMixed, EnumIsKnown) {
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::FIRST));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::SECOND));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::THREE_WORD_ENUM));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::kFirst));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::kTwoWord));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::kThreeWordEnum));
+  EXPECT_TRUE(EnumIsKnown(EnumMixed::kLongEnumValueName));
+  EXPECT_FALSE(EnumIsKnown(static_cast<EnumMixed>(999)));
+}
+
 TEST(EnumMixed, NameToEnum) {
   EnumMixed result;
 
   EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
   EXPECT_EQ(EnumMixed::FIRST, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
-  EXPECT_EQ(EnumMixed::kFirst, result);
   EXPECT_TRUE(TryToGetEnumFromName("SECOND", &result));
   EXPECT_EQ(EnumMixed::SECOND, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("TWO_WORD", &result));
   EXPECT_EQ(EnumMixed::kTwoWord, result);
   EXPECT_TRUE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
   EXPECT_EQ(EnumMixed::THREE_WORD_ENUM, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
-  EXPECT_EQ(EnumMixed::kThreeWordEnum, result);
-  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_TRUE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
   EXPECT_EQ(EnumMixed::kLongEnumValueName, result);
- }
+}
 
-TEST(EnumMixed, NameToEnumFailsWithWrongCases) {
-  EnumMixed result = EnumMixed::FIRST;
+TEST(EnumMixed, NameToEnumFailsWithKCamel) {
+  EnumShoutyAndKCamel result = EnumShoutyAndKCamel::FIRST;
+
+  EXPECT_FALSE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
   EXPECT_FALSE(TryToGetEnumFromName("kSecond", &result));
-  EXPECT_EQ(EnumMixed::FIRST, result);
-  EXPECT_FALSE(TryToGetEnumFromName("TWO_WORD", &result));
-  EXPECT_EQ(EnumMixed::FIRST, result);
-  EXPECT_FALSE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
-  EXPECT_EQ(EnumMixed::FIRST, result);
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
 }
 
 TEST(EnumMixed, EnumToName) {
   EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumMixed::FIRST));
   EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumMixed::kFirst));
   EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumMixed::SECOND));
-  EXPECT_EQ("kTwoWord", TryToGetNameFromEnum(EnumMixed::kTwoWord));
-  EXPECT_EQ("kThreeWordEnum",
+  EXPECT_EQ("TWO_WORD", TryToGetNameFromEnum(EnumMixed::kTwoWord));
+  EXPECT_EQ("THREE_WORD_ENUM",
     TryToGetNameFromEnum(EnumMixed::THREE_WORD_ENUM));
-  EXPECT_EQ("kThreeWordEnum",
+  EXPECT_EQ("THREE_WORD_ENUM",
     TryToGetNameFromEnum(EnumMixed::kThreeWordEnum));
-  EXPECT_EQ("kLongEnumValueName",
+  EXPECT_EQ("LONG_ENUM_VALUE_NAME",
     TryToGetNameFromEnum(EnumMixed::kLongEnumValueName));
+}
+
+TEST(UseKCamelEnumCase, IsValidToUse) {
+  std::array<uint8_t, UseKCamelEnumCase::IntrinsicSizeInBytes()> buffer;
+  auto view = MakeUseKCamelEnumCaseView(&buffer);
+
+  EXPECT_EQ(UseKCamelEnumCase::first(), EnumDefault::kFirst);
+  EXPECT_EQ(view.first().Read(), EnumDefault::kFirst);
+
+  EXPECT_TRUE(view.v().TryToWrite(EnumDefault::kSecond));
+  EXPECT_FALSE(view.v_is_first().Read());
+
+  EXPECT_TRUE(view.v().TryToWrite(EnumDefault::kFirst));
+  EXPECT_TRUE(view.v_is_first().Read());
+}
+
+TEST(UseKCamelEnumCase, TextStream) {
+  std::array<uint8_t, UseKCamelEnumCase::IntrinsicSizeInBytes()> buffer;
+  auto view = MakeUseKCamelEnumCaseView(&buffer);
+
+  EXPECT_TRUE(view.v().TryToWrite(EnumDefault::kSecond));
+  EXPECT_EQ(WriteToString(view), "{ v: SECOND }");
+  EXPECT_TRUE(UpdateFromText(view, "{ v: TWO_WORD }"));
+  EXPECT_EQ(view.v().Read(), EnumDefault::kTwoWord);
 }
 
 }  // namespace

--- a/compiler/back_end/cpp/testcode/enum_case_test.cc
+++ b/compiler/back_end/cpp/testcode/enum_case_test.cc
@@ -1,0 +1,219 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests the `enum_case` attribute generating the correct case. Note that since
+// these tests are regarding the name of enum members, it is likely that if this
+// test would fail, it may fail to compile.
+
+#include "gtest/gtest.h"
+#include "testdata/enum_case.emb.h"
+
+namespace emboss {
+namespace test {
+namespace {
+
+TEST(EnumShouty, AccessValuesByNameInSource) {
+  EXPECT_EQ(static_cast<int>(EnumShouty::FIRST), 0);
+  EXPECT_EQ(static_cast<int>(EnumShouty::SECOND), 1);
+  EXPECT_EQ(static_cast<int>(EnumShouty::TWO_WORD), 2);
+  EXPECT_EQ(static_cast<int>(EnumShouty::THREE_WORD_ENUM), 4);
+  EXPECT_EQ(static_cast<int>(EnumShouty::LONG_ENUM_VALUE_NAME), 8);
+}
+
+TEST(EnumShouty, NameToEnum) {
+  EnumShouty result;
+
+  EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
+  EXPECT_EQ(EnumShouty::FIRST, result);
+  EXPECT_TRUE(TryToGetEnumFromName("SECOND", &result));
+  EXPECT_EQ(EnumShouty::SECOND, result);
+  EXPECT_TRUE(TryToGetEnumFromName("TWO_WORD", &result));
+  EXPECT_EQ(EnumShouty::TWO_WORD, result);
+  EXPECT_TRUE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
+  EXPECT_EQ(EnumShouty::THREE_WORD_ENUM, result);
+  EXPECT_TRUE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
+  EXPECT_EQ(EnumShouty::LONG_ENUM_VALUE_NAME, result);
+}
+
+TEST(EnumShouty, NameToEnumFailsWithKCamel) {
+  EnumShouty result = EnumShouty::FIRST;
+
+  EXPECT_FALSE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_EQ(EnumShouty::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumShouty::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumShouty::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumShouty::FIRST, result);
+}
+
+TEST(EnumShouty, EnumToName) {
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumShouty::FIRST));
+  EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumShouty::SECOND));
+  EXPECT_EQ("TWO_WORD", TryToGetNameFromEnum(EnumShouty::TWO_WORD));
+  EXPECT_EQ("THREE_WORD_ENUM",
+    TryToGetNameFromEnum(EnumShouty::THREE_WORD_ENUM));
+  EXPECT_EQ("LONG_ENUM_VALUE_NAME",
+    TryToGetNameFromEnum(EnumShouty::LONG_ENUM_VALUE_NAME));
+}
+
+TEST(EnumDefault, AccessValuesByNameInSource) {
+  EXPECT_EQ(static_cast<int>(EnumDefault::kFirst), 0);
+  EXPECT_EQ(static_cast<int>(EnumDefault::kSecond), 1);
+  EXPECT_EQ(static_cast<int>(EnumDefault::kTwoWord), 2);
+  EXPECT_EQ(static_cast<int>(EnumDefault::kThreeWordEnum), 4);
+  EXPECT_EQ(static_cast<int>(EnumDefault::kLongEnumValueName), 8);
+}
+
+TEST(EnumDefault, NameToEnum) {
+  EnumDefault result;
+
+  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_EQ(EnumDefault::kSecond, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumDefault::kTwoWord, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumDefault::kThreeWordEnum, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumDefault::kLongEnumValueName, result);
+}
+
+TEST(EnumDefault, NameToEnumFailsWithShouty) {
+  EnumDefault result = EnumDefault::kFirst;
+
+  EXPECT_FALSE(TryToGetEnumFromName("SECOND", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+  EXPECT_FALSE(TryToGetEnumFromName("TWO_WORD", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+  EXPECT_FALSE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+  EXPECT_FALSE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
+  EXPECT_EQ(EnumDefault::kFirst, result);
+}
+
+TEST(EnumDefault, EnumToName) {
+  EXPECT_EQ("kFirst", TryToGetNameFromEnum(EnumDefault::kFirst));
+  EXPECT_EQ("kSecond", TryToGetNameFromEnum(EnumDefault::kSecond));
+  EXPECT_EQ("kTwoWord", TryToGetNameFromEnum(EnumDefault::kTwoWord));
+  EXPECT_EQ("kThreeWordEnum",
+    TryToGetNameFromEnum(EnumDefault::kThreeWordEnum));
+  EXPECT_EQ("kLongEnumValueName",
+    TryToGetNameFromEnum(EnumDefault::kLongEnumValueName));
+}
+
+TEST(EnumShoutyAndKCamel, AccessValuesByNameInSource) {
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::FIRST), 0);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kFirst), 0);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::SECOND), 1);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kSecond), 1);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::TWO_WORD), 2);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kTwoWord), 2);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::THREE_WORD_ENUM), 4);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kThreeWordEnum), 4);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::LONG_ENUM_VALUE_NAME), 8);
+  EXPECT_EQ(static_cast<int>(EnumShoutyAndKCamel::kLongEnumValueName), 8);
+}
+
+TEST(EnumShoutyAndKCamel, NameToEnum) {
+  EnumShoutyAndKCamel result;
+
+  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::kFirst, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::kSecond, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::kTwoWord, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::kThreeWordEnum, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::kLongEnumValueName, result);
+
+  EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::FIRST, result);
+  EXPECT_TRUE(TryToGetEnumFromName("SECOND", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::SECOND, result);
+  EXPECT_TRUE(TryToGetEnumFromName("TWO_WORD", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::TWO_WORD, result);
+  EXPECT_TRUE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::THREE_WORD_ENUM, result);
+  EXPECT_TRUE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
+  EXPECT_EQ(EnumShoutyAndKCamel::LONG_ENUM_VALUE_NAME, result);
+}
+
+TEST(EnumShoutyAndKCamel, EnumToName) {
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumShoutyAndKCamel::FIRST));
+  EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumShoutyAndKCamel::SECOND));
+  EXPECT_EQ("TWO_WORD", TryToGetNameFromEnum(EnumShoutyAndKCamel::TWO_WORD));
+  EXPECT_EQ("THREE_WORD_ENUM",
+    TryToGetNameFromEnum(EnumShoutyAndKCamel::THREE_WORD_ENUM));
+  EXPECT_EQ("LONG_ENUM_VALUE_NAME",
+    TryToGetNameFromEnum(EnumShoutyAndKCamel::LONG_ENUM_VALUE_NAME));
+
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumShoutyAndKCamel::kFirst));
+  EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumShoutyAndKCamel::kSecond));
+  EXPECT_EQ("TWO_WORD", TryToGetNameFromEnum(EnumShoutyAndKCamel::kTwoWord));
+  EXPECT_EQ("THREE_WORD_ENUM",
+    TryToGetNameFromEnum(EnumShoutyAndKCamel::kThreeWordEnum));
+  EXPECT_EQ("LONG_ENUM_VALUE_NAME",
+    TryToGetNameFromEnum(EnumShoutyAndKCamel::kLongEnumValueName));
+}
+
+TEST(EnumMixed, NameToEnum) {
+  EnumMixed result;
+
+  EXPECT_TRUE(TryToGetEnumFromName("FIRST", &result));
+  EXPECT_EQ(EnumMixed::FIRST, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kFirst", &result));
+  EXPECT_EQ(EnumMixed::kFirst, result);
+  EXPECT_TRUE(TryToGetEnumFromName("SECOND", &result));
+  EXPECT_EQ(EnumMixed::SECOND, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kTwoWord", &result));
+  EXPECT_EQ(EnumMixed::kTwoWord, result);
+  EXPECT_TRUE(TryToGetEnumFromName("THREE_WORD_ENUM", &result));
+  EXPECT_EQ(EnumMixed::THREE_WORD_ENUM, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kThreeWordEnum", &result));
+  EXPECT_EQ(EnumMixed::kThreeWordEnum, result);
+  EXPECT_TRUE(TryToGetEnumFromName("kLongEnumValueName", &result));
+  EXPECT_EQ(EnumMixed::kLongEnumValueName, result);
+ }
+
+TEST(EnumMixed, NameToEnumFailsWithWrongCases) {
+  EnumMixed result = EnumMixed::FIRST;
+  EXPECT_FALSE(TryToGetEnumFromName("kSecond", &result));
+  EXPECT_EQ(EnumMixed::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("TWO_WORD", &result));
+  EXPECT_EQ(EnumMixed::FIRST, result);
+  EXPECT_FALSE(TryToGetEnumFromName("LONG_ENUM_VALUE_NAME", &result));
+  EXPECT_EQ(EnumMixed::FIRST, result);
+}
+
+TEST(EnumMixed, EnumToName) {
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumMixed::FIRST));
+  EXPECT_EQ("FIRST", TryToGetNameFromEnum(EnumMixed::kFirst));
+  EXPECT_EQ("SECOND", TryToGetNameFromEnum(EnumMixed::SECOND));
+  EXPECT_EQ("kTwoWord", TryToGetNameFromEnum(EnumMixed::kTwoWord));
+  EXPECT_EQ("kThreeWordEnum",
+    TryToGetNameFromEnum(EnumMixed::THREE_WORD_ENUM));
+  EXPECT_EQ("kThreeWordEnum",
+    TryToGetNameFromEnum(EnumMixed::kThreeWordEnum));
+  EXPECT_EQ("kLongEnumValueName",
+    TryToGetNameFromEnum(EnumMixed::kLongEnumValueName));
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace emboss

--- a/compiler/front_end/attribute_checker.py
+++ b/compiler/front_end/attribute_checker.py
@@ -397,17 +397,6 @@ def _verify_width_attribute_on_enum(enum, type_definition, source_file_name,
     ])
 
 
-def _gather_default_attributes(obj, defaults):
-  defaults = defaults.copy()
-  for attr in obj.attribute:
-    if attr.is_default:
-      defaulted_attr = ir_pb2.Attribute()
-      defaulted_attr.CopyFrom(attr)
-      defaulted_attr.is_default = False
-      defaults[attr.name.text] = defaulted_attr
-  return {"defaults": defaults}
-
-
 def _add_missing_attributes_on_ir(ir):
   """Adds missing attributes in a complete IR."""
   traverse_ir.fast_traverse_ir_top_down(
@@ -419,17 +408,17 @@ def _add_missing_attributes_on_ir(ir):
   traverse_ir.fast_traverse_ir_top_down(
       ir, [ir_pb2.Structure], _add_missing_size_attributes_on_structure,
       incidental_actions={
-          ir_pb2.Module: _gather_default_attributes,
-          ir_pb2.TypeDefinition: _gather_default_attributes,
-          ir_pb2.Field: _gather_default_attributes,
+          ir_pb2.Module: attribute_util.gather_default_attributes,
+          ir_pb2.TypeDefinition: attribute_util.gather_default_attributes,
+          ir_pb2.Field: attribute_util.gather_default_attributes,
       },
       parameters={"defaults": {}})
   traverse_ir.fast_traverse_ir_top_down(
       ir, [ir_pb2.Field], _add_missing_byte_order_attribute_on_field,
       incidental_actions={
-          ir_pb2.Module: _gather_default_attributes,
-          ir_pb2.TypeDefinition: _gather_default_attributes,
-          ir_pb2.Field: _gather_default_attributes,
+          ir_pb2.Module: attribute_util.gather_default_attributes,
+          ir_pb2.TypeDefinition: attribute_util.gather_default_attributes,
+          ir_pb2.Field: attribute_util.gather_default_attributes,
       },
       parameters={"defaults": {}})
   return []

--- a/compiler/util/attribute_util.py
+++ b/compiler/util/attribute_util.py
@@ -287,7 +287,7 @@ def _check_attributes(attribute_list, types, back_end, attribute_specs,
 
 
 def gather_default_attributes(obj, defaults):
-  """Gather default attributes for an IR object
+  """Gathers default attributes for an IR object
 
   This is designed to be able to be used as-is as an incidental action in an IR
   traversal to accumulate defaults for child nodes.

--- a/compiler/util/attribute_util.py
+++ b/compiler/util/attribute_util.py
@@ -284,3 +284,26 @@ def _check_attributes(attribute_list, types, back_end, attribute_specs,
     else:
       errors.extend(types[attr.name.text](attr, module_source_file))
   return errors
+
+
+def gather_default_attributes(obj, defaults):
+  """Gather default attributes for an IR object
+
+  This is designed to be able to be used as-is as an incidental action in an IR
+  traversal to accumulate defaults for child nodes.
+
+  Arguments:
+    defaults: A dict of `{ "defaults": { attr.name.text: attr } }`
+
+  Returns:
+    A dict of `{ "defaults": { attr.name.text: attr } }` with any defaults
+    provided by `obj` added/overridden.
+  """
+  defaults = defaults.copy()
+  for attr in obj.attribute:
+    if attr.is_default:
+      defaulted_attr = ir_pb2.Attribute()
+      defaulted_attr.CopyFrom(attr)
+      defaulted_attr.is_default = False
+      defaults[attr.name.text] = defaulted_attr
+  return {"defaults": defaults}

--- a/compiler/util/name_conversion.py
+++ b/compiler/util/name_conversion.py
@@ -14,6 +14,58 @@
 
 """Conversions between snake-, camel-, and shouty-case names."""
 
+from enum import Enum
 
+
+class Case(str, Enum):
+  SNAKE = "snake_case"
+  SHOUTY = "SHOUTY_CASE"
+  CAMEL = "CamelCase"
+  K_CAMEL = "kCamelCase"
+
+
+# Map of (from, to) cases to their conversion function. Initially only contains
+# identity case conversions, additional conversions are added with the
+# _case_conversion decorator.
+_case_conversions = {(case.value, case.value): lambda x: x for case in Case}
+
+
+def _case_conversion(case_from, case_to):
+  """Decorator to dynamically dispatch case conversions at runtime."""
+  def _func(f):
+    _case_conversions[case_from, case_to] = f
+    return f
+
+  return _func
+
+
+@_case_conversion(Case.SNAKE, Case.CAMEL)
+@_case_conversion(Case.SHOUTY, Case.CAMEL)
 def snake_to_camel(name):
+  """Convert from snake_case to CamelCase. Also works from SHOUTY_CASE."""
   return "".join(word.capitalize() for word in name.split("_"))
+
+
+@_case_conversion(Case.CAMEL, Case.K_CAMEL)
+def camel_to_k_camel(name):
+  """Convert from CamelCase to kCamelCase."""
+  return "k" + name
+
+
+@_case_conversion(Case.SNAKE, Case.K_CAMEL)
+@_case_conversion(Case.SHOUTY, Case.K_CAMEL)
+def snake_to_k_camel(name):
+  """Convert from snake_case to kCamelCase. Also works from SHOUTY_CASE."""
+  return camel_to_k_camel(snake_to_camel(name))
+
+
+def convert_case(case_from, case_to, value):
+  """Convert cases based on runtime case values.
+
+  Note: Cases can be strings or enum values."""
+  return _case_conversions[case_from, case_to](value)
+
+
+def is_case_conversion_supported(case_from, case_to):
+  """Determine if a case conversion would be supported"""
+  return (case_from, case_to) in _case_conversions

--- a/compiler/util/name_conversion.py
+++ b/compiler/util/name_conversion.py
@@ -55,17 +55,17 @@ def camel_to_k_camel(name):
 @_case_conversion(Case.SNAKE, Case.K_CAMEL)
 @_case_conversion(Case.SHOUTY, Case.K_CAMEL)
 def snake_to_k_camel(name):
-  """Convert from snake_case to kCamelCase. Also works from SHOUTY_CASE."""
+  """Converts from snake_case to kCamelCase. Also works from SHOUTY_CASE."""
   return camel_to_k_camel(snake_to_camel(name))
 
 
 def convert_case(case_from, case_to, value):
-  """Convert cases based on runtime case values.
+  """Converts cases based on runtime case values.
 
   Note: Cases can be strings or enum values."""
   return _case_conversions[case_from, case_to](value)
 
 
 def is_case_conversion_supported(case_from, case_to):
-  """Determine if a case conversion would be supported"""
+  """Determines if a case conversion would be supported"""
   return (case_from, case_to) in _case_conversions

--- a/compiler/util/name_conversion_test.py
+++ b/compiler/util/name_conversion_test.py
@@ -29,6 +29,61 @@ class NameConversionTest(unittest.TestCase):
     self.assertEqual("Abc89Def", name_conversion.snake_to_camel("abc_89_def"))
     self.assertEqual("Abc89def", name_conversion.snake_to_camel("abc_89def"))
 
+  def test_shouty_to_camel(self):
+    self.assertEqual("Abc", name_conversion.snake_to_camel("ABC"))
+    self.assertEqual("AbcDef", name_conversion.snake_to_camel("ABC_DEF"))
+    self.assertEqual("AbcDef89", name_conversion.snake_to_camel("ABC_DEF89"))
+    self.assertEqual("AbcDef89", name_conversion.snake_to_camel("ABC_DEF_89"))
+    self.assertEqual("Abc89Def", name_conversion.snake_to_camel("ABC_89_DEF"))
+    self.assertEqual("Abc89def", name_conversion.snake_to_camel("ABC_89DEF"))
+
+  def test_camel_to_k_camel(self):
+    self.assertEqual("kFoo", name_conversion.camel_to_k_camel("Foo"))
+    self.assertEqual("kFooBar", name_conversion.camel_to_k_camel("FooBar"))
+    self.assertEqual("kAbc123", name_conversion.camel_to_k_camel("Abc123"))
+
+  def test_snake_to_k_camel(self):
+    self.assertEqual("kAbc", name_conversion.snake_to_k_camel("abc"))
+    self.assertEqual("kAbcDef", name_conversion.snake_to_k_camel("abc_def"))
+    self.assertEqual("kAbcDef89",
+                     name_conversion.snake_to_k_camel("abc_def89"))
+    self.assertEqual("kAbcDef89",
+                     name_conversion.snake_to_k_camel("abc_def_89"))
+    self.assertEqual("kAbc89Def",
+                     name_conversion.snake_to_k_camel("abc_89_def"))
+    self.assertEqual("kAbc89def",
+                     name_conversion.snake_to_k_camel("abc_89def"))
+
+  def test_shouty_to_k_camel(self):
+    self.assertEqual("kAbc", name_conversion.snake_to_k_camel("ABC"))
+    self.assertEqual("kAbcDef", name_conversion.snake_to_k_camel("ABC_DEF"))
+    self.assertEqual("kAbcDef89",
+                     name_conversion.snake_to_k_camel("ABC_DEF89"))
+    self.assertEqual("kAbcDef89",
+                     name_conversion.snake_to_k_camel("ABC_DEF_89"))
+    self.assertEqual("kAbc89Def",
+                     name_conversion.snake_to_k_camel("ABC_89_DEF"))
+    self.assertEqual("kAbc89def",
+                     name_conversion.snake_to_k_camel("ABC_89DEF"))
+
+  def test_convert_case(self):
+    self.assertEqual("foo_bar_123", name_conversion.convert_case(
+      "snake_case", "snake_case", "foo_bar_123"))
+    self.assertEqual("FOO_BAR_123", name_conversion.convert_case(
+      "SHOUTY_CASE", "SHOUTY_CASE", "FOO_BAR_123"))
+    self.assertEqual("kFooBar123", name_conversion.convert_case(
+      "kCamelCase", "kCamelCase", "kFooBar123"))
+    self.assertEqual("FooBar123", name_conversion.convert_case(
+      "CamelCase", "CamelCase", "FooBar123"))
+    self.assertEqual("kAbcDef", name_conversion.convert_case(
+      "snake_case", "kCamelCase", "abc_def"))
+    self.assertEqual("AbcDef", name_conversion.convert_case(
+      "snake_case", "CamelCase", "abc_def"))
+    self.assertEqual("kAbcDef", name_conversion.convert_case(
+      "SHOUTY_CASE", "kCamelCase", "ABC_DEF"))
+    self.assertEqual("AbcDef", name_conversion.convert_case(
+      "SHOUTY_CASE", "CamelCase", "ABC_DEF"))
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/doc/design_docs/archive/alternate_enum_cases.md
+++ b/doc/design_docs/archive/alternate_enum_cases.md
@@ -1,5 +1,9 @@
 # Design: Alternate Enum Field Cases
 
+This document is provided for historical interest.  This feature is now
+implemented in the form of the `[enum_case]` attribute on `enum` values, which
+can also be `$default`ed on module, struct, bits, and enum definitions.
+
 ## Motivation
 
 Currently, the Emboss compiler requires that enum fields are `SHOUTY_CASE`, but

--- a/doc/language-reference.md
+++ b/doc/language-reference.md
@@ -222,6 +222,33 @@ this module.
 The `namespace` attribute may only be used at the module level; all structures
 and enums within a module will be placed in the same namespace.
 
+### `(cpp) enum_case`
+
+The `enum_case` attribute can be specified for the C++ backend to specify
+in which case the enum values should be emitted to generated source. It does
+not change the text representation, which always uses the original emboss
+definition name as the canonical name.
+
+Currently, the supported cases are`SHOUTY_CASE` and `kCamelCase`.
+
+A `$default` enum case can be set on a module, struct, bits, or enum and
+applies to all enum values within that module, struct, bits, or enum
+definition.
+
+For example, to use `kCamelCase` by default for all enum values in a module:
+
+```
+[$default enum_case: "kCamelCase"]
+```
+
+This will change enum names like `UPPER_CHANNEL_RANGE_LIMIT` to
+`kUpperChannelRangeLimit` in the C++ source for all enum values in the module.
+Multiple case names can be specified, which is especially useful when
+transitioning between two cases:
+
+```
+[enum_case: "SHOUTY_CASE, kCamelCase"]
+```
 
 ### `text_output`
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -47,6 +47,7 @@ filegroup(
         "cpp_namespace.emb",
         "dynamic_size.emb",
         "enum.emb",
+        "enum_case.emb",
         "explicit_sizes.emb",
         "float.emb",
         "imported.emb",
@@ -103,6 +104,13 @@ emboss_cc_library(
     name = "enum_emboss",
     srcs = [
         "enum.emb",
+    ],
+)
+
+emboss_cc_library(
+    name = "enum_case_emboss",
+    srcs = [
+        "enum_case.emb",
     ],
 )
 

--- a/testdata/enum_case.emb
+++ b/testdata/enum_case.emb
@@ -31,6 +31,11 @@ enum EnumDefault:
   THREE_WORD_ENUM      = 4
   LONG_ENUM_VALUE_NAME = 8
 
+struct UseKCamelEnumCase:
+  0 [+4] EnumDefault v
+  let first = EnumDefault.FIRST
+  let v_is_first = v == EnumDefault.FIRST
+
 enum EnumShoutyAndKCamel:
   [(cpp) $default enum_case: "SHOUTY_CASE, kCamelCase"]
   FIRST                = 0

--- a/testdata/enum_case.emb
+++ b/testdata/enum_case.emb
@@ -1,0 +1,50 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[$default byte_order: "LittleEndian"]
+[(cpp) namespace: "emboss::test"]
+[(cpp) $default enum_case: "kCamelCase"]
+
+enum EnumShouty:
+  [(cpp) $default enum_case: "SHOUTY_CASE"]
+  FIRST                = 0
+  SECOND               = 1
+  TWO_WORD             = 2
+  THREE_WORD_ENUM      = 4
+  LONG_ENUM_VALUE_NAME = 8
+
+enum EnumDefault:
+  FIRST                = 0
+  SECOND               = 1
+  TWO_WORD             = 2
+  THREE_WORD_ENUM      = 4
+  LONG_ENUM_VALUE_NAME = 8
+
+enum EnumShoutyAndKCamel:
+  [(cpp) $default enum_case: "SHOUTY_CASE, kCamelCase"]
+  FIRST                = 0
+  SECOND               = 1
+  TWO_WORD             = 2
+  THREE_WORD_ENUM      = 4
+  LONG_ENUM_VALUE_NAME = 8
+
+enum EnumMixed:
+  -- Tests mixing various `enum_case` values in the same enum definition.
+  FIRST                = 0  [(cpp) enum_case: "SHOUTY_CASE, kCamelCase"]
+  SECOND               = 1  [(cpp) enum_case: "SHOUTY_CASE"]
+  TWO_WORD             = 2
+      [(cpp) enum_case: "kCamelCase"]
+  THREE_WORD_ENUM      = 4
+      [(cpp) enum_case: "kCamelCase, SHOUTY_CASE"]
+  LONG_ENUM_VALUE_NAME = 8


### PR DESCRIPTION
Implements the `enum_case` attribute in the C++ backend to support emitting enum values with a case other than SHOUTY_CASE. Currently only the original SHOUTY_CASE and the new kCamelCase cases are supported, but adding a new case should be trivial.

Additionally, the implementation was designed to make it simple for a `name` attribute to be added for enum values (other IR nodes should be unaffected, it would be neither simpler nor harder to implement after this commit for other nodes).

Tests were added for case conversions, header generation, and a cc_test. All tests pass both in `bazel test` and `python -m unittest`.

A small change was made to the front-end, as some attribute handling functions were hoisted into `compiler/util` for reuse in the backend.