### PR TITLE
Disable clang-tidy lint in C++ header body

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -37,7 +37,9 @@
 
 $_includes_$
 
+// NOLINTBEGIN
 $_body_$
+// NOLINTEND
 
 #endif  // $_header_guard_$
 


### PR DESCRIPTION
Disable all clang-tidy linting in C++ the body of the C++ outline template. This fixes several readability lint errors downstream.