### PR TITLE
Fix subscripted types for Python 3.8

### DIFF
--- a/compiler/back_end/cpp/attributes.py
+++ b/compiler/back_end/cpp/attributes.py
@@ -31,7 +31,7 @@ TYPES = {
 }
 
 
-class Scope(set[tuple[Attribute, bool]], Enum):
+class Scope(set, Enum):
     """Allowed scopes for C++ backend attributes.
 
     Each entry is a set of (Attribute, default?) tuples, the first value being


### PR DESCRIPTION
The changes in PR #89 inadvertently added a line that is incompatible with Python version 3.8. However, Python 3.8 is still supported for around one more year from now (https://devguide.python.org/versions/), so this change restores 3.8 compatibility.