### PR TITLE
Fix emboss_cpp_library Bazel rule

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -212,6 +212,7 @@ _cc_emboss_aspect = aspect(
             default = "@com_google_emboss//runtime/cpp:cpp_utils",
         ),
     },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )
 
 def _cc_emboss_library_impl(ctx):


### PR DESCRIPTION
Add `toolchains` parameter to _cc_emboss_aspect rule to fix find_cpp_toolchain error.

Fixes #103