### PR TITLE
Fix `import_dirs` support

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -95,7 +95,7 @@ def _emboss_library_impl(ctx):
     )
 
     imports = ["--import-dir=" + root for root in transitive_roots.to_list()]
-    imports_arg = ["--import-dir=" + impt for impt in ctx.attr.import_dirs]
+    imports_arg = ["--import-dir=" + impt.path for impt in ctx.files.import_dirs]
     ctx.actions.run(
         inputs = inputs.to_list(),
         outputs = [out],

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -53,6 +53,8 @@ filegroup(
         "imported.emb",
         "imported_genfiles.emb",
         "importer.emb",
+        "import_dir/project/imported.emb",
+        "import_dir/project/importer.emb",
         "int_sizes.emb",
         "nested_structure.emb",
         "no_cpp_namespace.emb",
@@ -128,6 +130,13 @@ emboss_cc_library(
     ],
 )
 
+emboss_cc_library(
+    name = "import_dir_imported_emboss",
+    srcs = [
+        "import_dir/project/imported.emb",
+    ],
+)
+
 # This rule is here to test that the Emboss Skylark macro sets eveything up
 # correctly for the Emboss front end to read generated .embs.
 #
@@ -164,6 +173,21 @@ emboss_cc_library(
         ":imported_genfiles_emboss",
     ],
 )
+
+# Tests that the `import_dirs` attribute works.
+emboss_cc_library(
+    name = "import_dir_importer_emboss",
+    srcs = [
+        "import_dir/project/importer.emb",
+    ],
+    deps = [
+        ":import_dir_imported_emboss",
+    ],
+    import_dirs = [
+        "import_dir",
+    ]
+)
+
 
 emboss_cc_library(
     name = "importer2_emboss",

--- a/testdata/import_dir/project/imported.emb
+++ b/testdata/import_dir/project/imported.emb
@@ -1,0 +1,20 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[$default byte_order: "LittleEndian"]
+[(cpp) namespace: "emboss::test"]
+
+
+struct Inner:
+  0 [+8]  UInt  value

--- a/testdata/import_dir/project/importer.emb
+++ b/testdata/import_dir/project/importer.emb
@@ -1,0 +1,30 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test .emb to ensure that the import system works.
+#
+# The file imported_genfiles.emb is identical to imported.emb except for the
+# [(cpp) namespace] attribute; it is used to ensure that generated .embs can be
+# used by the emboss_cc_library build rule.
+
+# These imports intentionally use names that do not match the file names, as a
+# test that the file names aren't being used.
+
+import "project/imported.emb" as imp
+
+[(cpp) namespace: "emboss::test"]
+
+
+struct Outer:
+  0 [+8]  imp.Inner      inner


### PR DESCRIPTION
`import_dirs` arguments come through as part of the `ctx.files` list and need to have their `path` extracted when building the `embossc` command-line. This CL also adds a `testdata` entry that checks that `emboss_cc_library` works when specifying `import_dirs`.

Test: `bazel build //testdata:import_dir_importer_emboss`