### PR TITLE
Remove references to deprecated allocator members

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+# Emboss doesn't (yet) support bzlmod.
+common --noenable_bzlmod
 # Emboss (at least notionally) supports C++11 until (at least) 2027.  However,
 # Googletest requires C++14, which means that all of the Emboss unit tests
 # require C++14 to run.

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -174,13 +174,13 @@ TEST(ContiguousBuffer, OffsetStorageType) {
 // std::basic_string<> with non-default trailing template parameters.
 template <class T>
 struct NonstandardAllocator {
-  using value_type = typename ::std::allocator<T>::value_type;
-  using pointer = typename ::std::allocator<T>::pointer;
-  using const_pointer = typename ::std::allocator<T>::const_pointer;
-  using reference = typename ::std::allocator<T>::reference;
-  using const_reference = typename ::std::allocator<T>::const_reference;
-  using size_type = typename ::std::allocator<T>::size_type;
-  using difference_type = typename ::std::allocator<T>::difference_type;
+  using value_type = typename ::std::allocator_traits<::std::allocator<T>>::value_type;
+  using pointer = typename ::std::allocator_traits<::std::allocator<T>>::pointer;
+  using const_pointer = typename ::std::allocator_traits<::std::allocator<T>>::const_pointer;
+  using reference = typename ::std::allocator<T>::value_type &;
+  using const_reference = const typename ::std::allocator_traits<::std::allocator<T>>::value_type &;
+  using size_type = typename ::std::allocator_traits<::std::allocator<T>>::size_type;
+  using difference_type = typename ::std::allocator_traits<::std::allocator<T>>::difference_type;
 
   template <class U>
   struct rebind {


### PR DESCRIPTION
These allocator members were deprecated in C++17 and deleted in C++20.

This upstreams cl/601574967.