### PR TITLE
Load py_library, py_binary from rules_python

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,25 +1,36 @@
 workspace(name = "com_google_emboss")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # googletest
 git_repository(
     name = "com_google_googletest",
-    remote = "https://github.com/google/googletest",
     commit = "2f2e72bae991138cedd0e3d06a115022736cd568",
+    remote = "https://github.com/google/googletest",
     shallow_since = "1563302555 -0400",
 )
 
 git_repository(
     name = "com_google_absl",
-    remote = "https://github.com/abseil/abseil-cpp",
     commit = "3020b58f0d987073b8adab204426f82c3f60b283",
+    remote = "https://github.com/abseil/abseil-cpp",
     shallow_since = "1562769772 +0000",
 )
 
 http_archive(
-  name = "bazel_skylib",
-  urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
-  sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+    name = "bazel_skylib",
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
 )
+
+http_archive(
+    name = "rules_python",
+    sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
+    strip_prefix = "rules_python-0.31.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+
+py_repositories()

--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -14,6 +14,9 @@
 
 # Emboss C++ code generator.
 
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
 load(":build_defs.bzl", "emboss_cc_test")
 
 package(
@@ -37,7 +40,7 @@ py_binary(
 py_library(
     name = "attributes",
     srcs = ["attributes.py"],
-    deps = []
+    deps = [],
 )
 
 py_library(

--- a/compiler/back_end/util/BUILD
+++ b/compiler/back_end/util/BUILD
@@ -14,6 +14,9 @@
 
 # Shared utilities for Emboss back ends.
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(
     default_visibility = ["//compiler:__subpackages__"],
 )

--- a/compiler/front_end/BUILD
+++ b/compiler/front_end/BUILD
@@ -18,6 +18,10 @@
 # intermediate representation (IR).  The IR is passed to back end code
 # generators to generate code in various languages.
 
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(
     default_visibility = [
         "//:__subpackages__",
@@ -135,8 +139,8 @@ py_library(
         ":tokenizer",
         ":type_check",
         ":write_inference",
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:parser_types",
         "//compiler/util:resources",
     ],
@@ -151,8 +155,8 @@ py_test(
     python_version = "PY3",
     deps = [
         ":glue",
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:parser_types",
         "//compiler/util:test_util",
     ],
@@ -163,8 +167,8 @@ py_library(
     srcs = ["synthetics.py"],
     visibility = ["//visibility:private"],
     deps = [
-        "//compiler/util:ir_pb2",
         "//compiler/util:expression_parser",
+        "//compiler/util:ir_pb2",
         "//compiler/util:traverse_ir",
     ],
 )
@@ -185,8 +189,8 @@ py_library(
     srcs = ["symbol_resolver.py"],
     visibility = ["//visibility:private"],
     deps = [
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:ir_util",
         "//compiler/util:traverse_ir",
     ],
@@ -257,8 +261,8 @@ py_test(
     deps = [
         ":attribute_checker",
         ":glue",
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:ir_util",
         "//compiler/util:test_util",
     ],
@@ -269,8 +273,8 @@ py_library(
     srcs = ["type_check.py"],
     deps = [
         ":attributes",
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:ir_util",
         "//compiler/util:traverse_ir",
     ],
@@ -321,8 +325,8 @@ py_library(
     ],
     deps = [
         ":attributes",
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:ir_util",
         "//compiler/util:resources",
         "//compiler/util:traverse_ir",
@@ -345,8 +349,8 @@ py_library(
     name = "dependency_checker",
     srcs = ["dependency_checker.py"],
     deps = [
-        "//compiler/util:ir_pb2",
         "//compiler/util:error",
+        "//compiler/util:ir_pb2",
         "//compiler/util:ir_util",
         "//compiler/util:traverse_ir",
     ],

--- a/compiler/util/BUILD
+++ b/compiler/util/BUILD
@@ -14,6 +14,9 @@
 
 # Shared utilities for Emboss back ends.
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 package(
     default_visibility = ["//compiler:__subpackages__"],
 )
@@ -100,8 +103,8 @@ py_library(
     name = "traverse_ir",
     srcs = ["traverse_ir.py"],
     deps = [
-        ":simple_memoizer",
         ":ir_pb2",
+        ":simple_memoizer",
     ],
 )
 
@@ -110,8 +113,8 @@ py_test(
     srcs = ["traverse_ir_test.py"],
     python_version = "PY3",
     deps = [
-        ":traverse_ir",
         ":ir_pb2",
+        ":traverse_ir",
     ],
 )
 
@@ -128,8 +131,8 @@ py_test(
     srcs = ["parser_types_test.py"],
     python_version = "PY3",
     deps = [
-        ":parser_types",
         ":ir_pb2",
+        ":parser_types",
     ],
 )
 

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -20,8 +20,8 @@
 filegroup(
     name = "grammar_md",
     srcs = [
-        "grammar.md",
         "__init__.py",
+        "grammar.md",
     ],
     # This should only be needed by docs_are_up_to_date_test.
     visibility = ["//:__subpackages__"],

--- a/integration/googletest/BUILD
+++ b/integration/googletest/BUILD
@@ -19,8 +19,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//runtime/cpp:cpp_utils",
-        "@com_google_googletest//:gtest",
         "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
     ],
 )
 
@@ -32,7 +32,7 @@ cc_test(
     copts = ["-Wsign-compare"],
     deps = [
         ":emboss_test_util",
-        "@com_google_googletest//:gtest_main",
         "//testdata:complex_structure_emboss",
+        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/runtime/cpp/test/BUILD
+++ b/runtime/cpp/test/BUILD
@@ -51,8 +51,8 @@ emboss_cc_util_test(
     copts = ["-DEMBOSS_FORCE_ALL_CHECKS"],
     deps = [
         "//runtime/cpp:cpp_utils",
-        "@com_google_googletest//:gtest_main",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -14,10 +14,11 @@
 
 # Shared test data for Emboss.
 
-load("//:build_defs.bzl",
-     "emboss_cc_library",
-     "emboss_library",
-     "cc_emboss_library"
+load(
+    "//:build_defs.bzl",
+    "cc_emboss_library",
+    "emboss_cc_library",
+    "emboss_library",
 )
 
 package(
@@ -27,17 +28,18 @@ package(
 filegroup(
     name = "golden_files",
     srcs = [
+        "golden/__init__.py",
         "golden/span_se_log_file_status.emb",
         "golden/span_se_log_file_status.ir.txt",
         "golden/span_se_log_file_status.parse_tree.txt",
         "golden/span_se_log_file_status.tokens.txt",
-        "golden/__init__.py",
     ],
 )
 
 filegroup(
     name = "test_embs",
     srcs = [
+        "__init__.py",
         "absolute_cpp_namespace.emb",
         "anonymous_bits.emb",
         "bcd.emb",
@@ -50,22 +52,21 @@ filegroup(
         "enum_case.emb",
         "explicit_sizes.emb",
         "float.emb",
+        "import_dir/project/imported.emb",
+        "import_dir/project/importer.emb",
         "imported.emb",
         "imported_genfiles.emb",
         "importer.emb",
-        "import_dir/project/imported.emb",
-        "import_dir/project/importer.emb",
         "int_sizes.emb",
         "nested_structure.emb",
-        "no_cpp_namespace.emb",
         "next_keyword.emb",
+        "no_cpp_namespace.emb",
         "parameters.emb",
         "requires.emb",
         "subtypes.emb",
         "text_format.emb",
         "uint_sizes.emb",
         "virtual_field.emb",
-        "__init__.py",
     ],
 )
 
@@ -180,14 +181,13 @@ emboss_cc_library(
     srcs = [
         "import_dir/project/importer.emb",
     ],
+    import_dirs = [
+        "import_dir",
+    ],
     deps = [
         ":import_dir_imported_emboss",
     ],
-    import_dirs = [
-        "import_dir",
-    ]
 )
-
 
 emboss_cc_library(
     name = "importer2_emboss",


### PR DESCRIPTION
This adds an explicit dependency on rules_python and loads py_library and py_binary rules from there, instead of relying on built-in versions in Bazel.

Doing so prepares us for the rollout of
https://github.com/bazelbuild/bazel/issues/15897 (which is happening internally already, and across the Bazel ecosystem soon).

Except for the change to the WORKSPACE file, this change was auto-generated by running,

    buildozer 'new_load @rules_python//python:py_library.bzl py_library' //...:__pkg__
    buildozer 'new_load @rules_python//python:py_binary.bzl py_binary' //...:__pkg__
    buildozer 'new_load @rules_python//python:py_test.bzl py_test' //...:__pkg__
    buildozer 'fix unusedLoads' //...:__pkg__

Upstreams cl/551628592.