### PR TITLE
Split out enum trait generation

### DIFF
--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -225,6 +225,17 @@ emboss_cc_test(
 )
 
 emboss_cc_test(
+    name = "no_enum_traits_test",
+    srcs = [
+        "testcode/no_enum_traits_test.cc",
+    ],
+    deps = [
+        "//testdata:no_enum_traits_emboss",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+emboss_cc_test(
     name = "start_size_range_test",
     srcs = [
         "testcode/start_size_range_test.cc",

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -179,57 +179,7 @@ ${size_method}
         emboss_reserved_local_other.IntrinsicSizeIn${units}().Read());
   }
 
-  template <class Stream>
-  bool UpdateFromTextStream(Stream *emboss_reserved_local_stream) const {
-    ::std::string emboss_reserved_local_brace;
-    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
-                                      &emboss_reserved_local_brace))
-      return false;
-    if (emboss_reserved_local_brace != "{") return false;
-    for (;;) {
-      ::std::string emboss_reserved_local_name;
-      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
-                                        &emboss_reserved_local_name))
-        return false;
-      if (emboss_reserved_local_name == ",")
-        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
-                                          &emboss_reserved_local_name))
-          return false;
-      if (emboss_reserved_local_name == "}") return true;
-      ::std::string emboss_reserved_local_colon;
-      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
-                                        &emboss_reserved_local_colon))
-        return false;
-      if (emboss_reserved_local_colon != ":") return false;
-${decode_fields}
-      // decode_fields will `continue` if it successfully finds a field.
-      return false;
-    }
-  }
-
-  template <class Stream>
-  void WriteToTextStream(
-      Stream *emboss_reserved_local_stream,
-      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
-    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
-        emboss_reserved_local_options.PlusOneIndent();
-    if (emboss_reserved_local_options.multiline()) {
-      emboss_reserved_local_stream->Write("{\n");
-    } else {
-      emboss_reserved_local_stream->Write("{");
-    }
-    bool emboss_reserved_local_wrote_field = false;
-${write_fields}
-    // Avoid unused variable warnings for empty structures:
-    (void)emboss_reserved_local_wrote_field;
-    if (emboss_reserved_local_options.multiline()) {
-      emboss_reserved_local_stream->Write(
-          emboss_reserved_local_options.current_indent());
-      emboss_reserved_local_stream->Write("}");
-    } else {
-      emboss_reserved_local_stream->Write(" }");
-    }
-  }
+${text_stream_methods}
 
   static constexpr bool IsAggregate() { return true; }
 
@@ -300,6 +250,60 @@ MakeAligned${name}View(
       ${forwarded_parameters} emboss_reserved_local_data,
       emboss_reserved_local_size);
 }
+
+// ** struct_text_stream ** ////////////////////////////////////////////////////
+  template <class Stream>
+  bool UpdateFromTextStream(Stream *emboss_reserved_local_stream) const {
+    ::std::string emboss_reserved_local_brace;
+    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                      &emboss_reserved_local_brace))
+      return false;
+    if (emboss_reserved_local_brace != "{") return false;
+    for (;;) {
+      ::std::string emboss_reserved_local_name;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_name))
+        return false;
+      if (emboss_reserved_local_name == ",")
+        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                          &emboss_reserved_local_name))
+          return false;
+      if (emboss_reserved_local_name == "}") return true;
+      ::std::string emboss_reserved_local_colon;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_colon))
+        return false;
+      if (emboss_reserved_local_colon != ":") return false;
+${decode_fields}
+      // decode_fields will `continue` if it successfully finds a field.
+      return false;
+    }
+  }
+
+  template <class Stream>
+  void WriteToTextStream(
+      Stream *emboss_reserved_local_stream,
+      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
+    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
+        emboss_reserved_local_options.PlusOneIndent();
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write("{\n");
+    } else {
+      emboss_reserved_local_stream->Write("{");
+    }
+    bool emboss_reserved_local_wrote_field = false;
+${write_fields}
+    // Avoid unused variable warnings for empty structures:
+    (void)emboss_reserved_local_wrote_field;
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write(
+          emboss_reserved_local_options.current_indent());
+      emboss_reserved_local_stream->Write("}");
+    } else {
+      emboss_reserved_local_stream->Write(" }");
+    }
+  }
+
 
 // ** decode_field ** //////////////////////////////////////////////////////////
       // If the field name matches ${field_name}, handle it, otherwise fall
@@ -772,6 +776,7 @@ ${enum_values}
 // "the output of this rule is an indeterminate number of files, all of which
 // should be used as input to this other rule," which would be necessary to
 // generate all the .cc files and then build and link them into a library.
+// ** enum_traits ** ///////////////////////////////////////////////////////////
 template <class Enum>
 class EnumTraits;
 

--- a/compiler/back_end/cpp/testcode/no_enum_traits_test.cc
+++ b/compiler/back_end/cpp/testcode/no_enum_traits_test.cc
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests that an emb compiled with enable_enum_traits = False actually compiles.
+
+#include <stdint.h>
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "testdata/no_enum_traits.emb.h"
+
+namespace emboss {
+namespace test {
+namespace {
+
+TEST(NoEnumTraits, Compiles) {
+  ::std::vector<uint8_t> backing_store(1);
+  auto view = MakeBarView(&backing_store);
+  view.foo().Write(Foo::VALUE);
+  EXPECT_TRUE(view.Ok());
+
+  // Check that we don't accidentally include `emboss_text_util.h` via our
+  // generated header.
+#ifdef EMBOSS_RUNTIME_CPP_EMBOSS_TEXT_UTIL_H_
+  const bool emboss_text_util_is_present = true;
+#else
+  const bool emboss_text_util_is_present = false;
+#endif
+
+  EXPECT_FALSE(emboss_text_util_is_present);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace emboss

--- a/embossc
+++ b/embossc
@@ -20,6 +20,7 @@ import argparse
 import os
 import sys
 
+
 def _parse_args(argv):
   parser = argparse.ArgumentParser(description="Emboss compiler")
   parser.add_argument("--color-output",
@@ -49,6 +50,11 @@ def _parse_args(argv):
                       nargs=1,
                       help="""File name to be used for the generated output
                               file. Defaults to input_file suffixed by '.h'""")
+  parser.add_argument("--cc-enum-traits",
+                      action=argparse.BooleanOptionalAction,
+                      default=True,
+                      help="""Controls generation of EnumTraits by the C++
+                              backend""")
   parser.add_argument("input_file",
                       type=str,
                       nargs=1,
@@ -62,7 +68,7 @@ def main(argv):
   sys.path.append(base_path)
 
   from compiler.back_end.cpp import ( # pylint:disable=import-outside-toplevel
-    emboss_codegen_cpp
+    emboss_codegen_cpp, header_generator
   )
   from compiler.front_end import ( # pylint:disable=import-outside-toplevel
     emboss_front_end
@@ -74,8 +80,9 @@ def main(argv):
   if errors:
     return 1
 
+  config = header_generator.Config(include_enum_traits=flags.cc_enum_traits)
   header, errors = emboss_codegen_cpp.generate_headers_and_log_errors(
-      ir, flags.color_output)
+      ir, flags.color_output, config)
 
   if errors:
     return 1

--- a/runtime/cpp/emboss_cpp_util.h
+++ b/runtime/cpp/emboss_cpp_util.h
@@ -25,7 +25,6 @@
 #include "runtime/cpp/emboss_defines.h"
 #include "runtime/cpp/emboss_enum_view.h"
 #include "runtime/cpp/emboss_memory_util.h"
-#include "runtime/cpp/emboss_text_util.h"
 #include "runtime/cpp/emboss_view_parameters.h"
 
 #endif  // EMBOSS_RUNTIME_CPP_EMBOSS_CPP_UTIL_H_

--- a/runtime/cpp/test/emboss_array_view_test.cc
+++ b/runtime/cpp/test/emboss_array_view_test.cc
@@ -20,6 +20,7 @@
 #include "absl/strings/str_format.h"
 #include "gtest/gtest.h"
 #include "runtime/cpp/emboss_prelude.h"
+#include "runtime/cpp/emboss_text_util.h"
 
 namespace emboss {
 namespace support {

--- a/runtime/cpp/test/emboss_cpp_util_google_integration_test.cc
+++ b/runtime/cpp/test/emboss_cpp_util_google_integration_test.cc
@@ -15,6 +15,7 @@
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 #include "runtime/cpp/emboss_cpp_util.h"
+#include "runtime/cpp/emboss_text_util.h"
 
 namespace emboss {
 namespace support {

--- a/runtime/cpp/test/emboss_enum_view_test.cc
+++ b/runtime/cpp/test/emboss_enum_view_test.cc
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 #include "runtime/cpp/emboss_prelude.h"
+#include "runtime/cpp/emboss_text_util.h"
 
 namespace emboss {
 namespace support {

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <string>
 #if __cplusplus >= 201703L
 #include <string_view>
 #endif  // __cplusplus >= 201703L
 #include <vector>
 
-#include "runtime/cpp/emboss_memory_util.h"
-
 #include "gtest/gtest.h"
+#include "runtime/cpp/emboss_memory_util.h"
 #include "runtime/cpp/emboss_prelude.h"
 
 namespace emboss {
@@ -175,13 +175,19 @@ TEST(ContiguousBuffer, OffsetStorageType) {
 // std::basic_string<> with non-default trailing template parameters.
 template <class T>
 struct NonstandardAllocator {
-  using value_type = typename ::std::allocator_traits<::std::allocator<T>>::value_type;
-  using pointer = typename ::std::allocator_traits<::std::allocator<T>>::pointer;
-  using const_pointer = typename ::std::allocator_traits<::std::allocator<T>>::const_pointer;
+  using value_type =
+      typename ::std::allocator_traits<::std::allocator<T>>::value_type;
+  using pointer =
+      typename ::std::allocator_traits<::std::allocator<T>>::pointer;
+  using const_pointer =
+      typename ::std::allocator_traits<::std::allocator<T>>::const_pointer;
   using reference = typename ::std::allocator<T>::value_type &;
-  using const_reference = const typename ::std::allocator_traits<::std::allocator<T>>::value_type &;
-  using size_type = typename ::std::allocator_traits<::std::allocator<T>>::size_type;
-  using difference_type = typename ::std::allocator_traits<::std::allocator<T>>::difference_type;
+  using const_reference =
+      const typename ::std::allocator_traits<::std::allocator<T>>::value_type &;
+  using size_type =
+      typename ::std::allocator_traits<::std::allocator<T>>::size_type;
+  using difference_type =
+      typename ::std::allocator_traits<::std::allocator<T>>::difference_type;
 
   template <class U>
   struct rebind {

--- a/runtime/cpp/test/emboss_prelude_test.cc
+++ b/runtime/cpp/test/emboss_prelude_test.cc
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "runtime/cpp/emboss_cpp_util.h"
+#include "runtime/cpp/emboss_text_util.h"
 
 namespace emboss {
 namespace prelude {

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -242,6 +242,14 @@ emboss_cc_library(
 )
 
 emboss_cc_library(
+    name = "no_enum_traits_emboss",
+    srcs = [
+        "no_enum_traits.emb",
+    ],
+    enable_enum_traits = False,
+)
+
+emboss_cc_library(
     name = "start_size_range_emboss",
     srcs = [
         "start_size_range.emb",

--- a/testdata/no_enum_traits.emb
+++ b/testdata/no_enum_traits.emb
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+-- Test .emb to ensure that compilation succedes if enum traits are disabled.
+
+[$default byte_order: "LittleEndian"]
+[(cpp) namespace: "emboss::test"]
+
+enum Foo:
+  VALUE = 10
+
+struct Bar:
+  0 [+1] Foo foo


### PR DESCRIPTION
This change makes the generation of EnumTraits configurable. With this
change we can see reductions in code size by over 1MB. Example file
size changes:

|File              | src (KB) | .h (KB) before | .h (KB) after |
|------------------|----------|----------------|---------------|
| hci_events.emb   |       76 |           5356 |          3884 |
| hci_commands.emb |      108 |           5612 |          4268 |
| hci_vendor.emb   |       32 |           1748 |          1304 |
| hci_common.emb   |       32 |            644 |           368 |
| hci_data.emb     |        4 |            152 |           104 |
| l2cap_frames.emb |        4 |             48 |            40 |
| hci_h4.emb       |        4 |              8 |             4 |

This is also helpful for embedded users who couldn't use emboss due to
dependencies on string libraries and functions like `sscanf`.

This change is split out into a series of patches to make it easier to review:
  - `Add forward declarations for text helpers` - Cleanup in preparation for the following changes. This allows us to remove the dependency on `emboss_text_util.h` from the core runtime files.
  - `Split out enum trait generation` - This is the main change, it adds a configuration flag that controls whether or not enum trait and various text helpers are generated
  - `Add --no-cc-enum-traits param` adds a CLI flag for toggling the internal configuration
  - `Add bazel support for disabling enum traits` adds an attribute to the emboss_cc_library to control the enum traits configuration as well as tests to make sure it works

This is part of #128 

**Tests:** `bazel test //...`