### PR TITLE
Add a default MODULE.bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
+# Bazel
 bazel-*
+MODULE.bazel.lock
+
+# Python
 __pycache__
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@ MODULE.bazel.lock
 
 # Python
 __pycache__
+.venv
+
+# IDEs
+.vscode
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,6 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################


### PR DESCRIPTION
Some versions of `bazel` have started generating a `MODULE.bazel` file
in preparation for the migration to `bzlmod`. This adds the default file
for now and updates `.gitignore` to ignore the associated lock file.