### PR TITLE
Bump required version to 3.9 and add it to bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,14 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz",
 )
 
-load("@rules_python//python:repositories.bzl", "py_repositories")
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 py_repositories()
+
+# Use Python 3.9 for bazel Python rules.
+python_register_toolchains(
+    name = "python3",
+    python_version = "3.9",
+)
+
+load("@python3//:defs.bzl", "interpreter")

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -24,7 +24,7 @@ emails.
 
 #### Running the Emboss Compiler
 
-The Emboss compiler requires Python 3.8 or later -- the minimum supported
+The Emboss compiler requires Python 3.9 or later -- the minimum supported
 version tracks the support timeline of the Python project.  On a Linux-like
 system with Python 3 installed in the usual place (`/usr/bin/python3`), you
 can run the embossc script at the top level on an `.emb` file to generate


### PR DESCRIPTION
This bumps the required version to 3.9 which is what our codebase currently requires. It also adds a bazel rule to install a hermetic python 3.9 package. This will make `bazel` always use the hermetic package which should avoid backwards compatibility issues in the future.

Fixes #136