### PR TITLE
Add `ir_data_utils.builder`

### DIFF
--- a/compiler/back_end/cpp/header_generator_test.py
+++ b/compiler/back_end/cpp/header_generator_test.py
@@ -19,6 +19,7 @@ from compiler.back_end.cpp import header_generator
 from compiler.front_end import glue
 from compiler.util import error
 from compiler.util import ir_data
+from compiler.util import ir_data_utils
 from compiler.util import test_util
 
 def _make_ir_from_emb(emb_text, name="m.emb"):
@@ -95,6 +96,7 @@ class NormalizeIrTest(unittest.TestCase):
     attr = ir.module[0].type[0].attribute[0]
 
     bad_case_source_location = ir_data.Location()
+    bad_case_source_location = ir_data_utils.builder(bad_case_source_location)
     bad_case_source_location.CopyFrom(attr.value.source_location)
     # Location of SHORTY_CASE in the attribute line.
     bad_case_source_location.start.column = 30
@@ -114,6 +116,7 @@ class NormalizeIrTest(unittest.TestCase):
     attr = ir.module[0].type[0].attribute[0]
 
     bad_case_source_location = ir_data.Location()
+    bad_case_source_location = ir_data_utils.builder(bad_case_source_location)
     bad_case_source_location.CopyFrom(attr.value.source_location)
     # Location of bad_CASE in the attribute line.
     bad_case_source_location.start.column = 43
@@ -133,6 +136,7 @@ class NormalizeIrTest(unittest.TestCase):
     attr = ir.module[0].type[0].attribute[0]
 
     bad_case_source_location = ir_data.Location()
+    bad_case_source_location = ir_data_utils.builder(bad_case_source_location)
     bad_case_source_location.CopyFrom(attr.value.source_location)
     # Location of BAD_case in the attribute line.
     bad_case_source_location.start.column = 55
@@ -152,6 +156,7 @@ class NormalizeIrTest(unittest.TestCase):
     attr = ir.module[0].type[0].attribute[0]
 
     bad_case_source_location = ir_data.Location()
+    bad_case_source_location = ir_data_utils.builder(bad_case_source_location)
     bad_case_source_location.CopyFrom(attr.value.source_location)
     # Location of the second SHOUTY_CASE in the attribute line.
     bad_case_source_location.start.column = 43
@@ -172,6 +177,7 @@ class NormalizeIrTest(unittest.TestCase):
     attr = ir.module[0].type[0].attribute[0]
 
     bad_case_source_location = ir_data.Location()
+    bad_case_source_location = ir_data_utils.builder(bad_case_source_location)
     bad_case_source_location.CopyFrom(attr.value.source_location)
     # Location of excess comma.
     bad_case_source_location.start.column = 42

--- a/compiler/front_end/symbol_resolver.py
+++ b/compiler/front_end/symbol_resolver.py
@@ -22,6 +22,7 @@ import collections
 
 from compiler.util import error
 from compiler.util import ir_data
+from compiler.util import ir_data_utils
 from compiler.util import ir_util
 from compiler.util import traverse_ir
 
@@ -133,7 +134,7 @@ def _add_name_to_scope_and_normalize(name_ir, scope, visibility, errors):
   """Adds the given name_ir to scope and sets its canonical_name."""
   name = name_ir.name.text
   canonical_name = _nested_name(scope.canonical_name, name)
-  name_ir.canonical_name.CopyFrom(canonical_name)
+  ir_data_utils.builder(name_ir).canonical_name.CopyFrom(canonical_name)
   return _add_name_to_scope(name_ir.name, scope, canonical_name, visibility,
                             errors)
 
@@ -282,7 +283,7 @@ def _resolve_reference(reference, table, current_scope, visible_scopes,
                                      visible_scopes, source_file_name, errors)
   if target is not None:
     assert not target.alias
-    reference.canonical_name.CopyFrom(target.canonical_name)
+    ir_data_utils.builder(reference).canonical_name.CopyFrom(target.canonical_name)
 
 
 def _find_target_of_reference(reference, table, current_scope, visible_scopes,
@@ -419,7 +420,7 @@ def _resolve_field_reference(field_reference, source_file_name, errors, ir):
     member_name = ir_data.CanonicalName()
     member_name.CopyFrom(
         previous_field.type.atomic_type.reference.canonical_name)
-    member_name.object_path.extend([ref.source_name[0].text])
+    ir_data_utils.builder(member_name).object_path.extend([ref.source_name[0].text])
     previous_field = ir_util.find_object_or_none(member_name, ir)
     if previous_field is None:
       errors.append(
@@ -427,7 +428,7 @@ def _resolve_field_reference(field_reference, source_file_name, errors, ir):
                              ref.source_name[0].source_location,
                              ref.source_name[0].text))
       return
-    ref.canonical_name.CopyFrom(member_name)
+    ir_data_utils.builder(ref).canonical_name.CopyFrom(member_name)
     previous_reference = ref
 
 

--- a/compiler/util/ir_data_utils.py
+++ b/compiler/util/ir_data_utils.py
@@ -29,3 +29,11 @@ class IrDataSerializer:
   def from_json(data_cls: type[ir_data.Message], data):
     """Constructs an IR data class from the given JSON string"""
     return data_cls.from_json(data)
+
+
+def builder(target: ir_data.Message) -> ir_data.Message:
+  """Provides a wrapper for building up IR data classes.
+
+  This is a no-op and just used for annotation for now.
+  """
+  return target

--- a/compiler/util/ir_util_test.py
+++ b/compiler/util/ir_util_test.py
@@ -32,14 +32,14 @@ class IrUtilTest(unittest.TestCase):
     self.assertTrue(ir_util.is_constant(_parse_expression("6")))
     expression = _parse_expression("12")
     # The type information should be ignored for constants like this one.
-    expression.type.integer.CopyFrom(ir_data.IntegerType())
+    ir_data_utils.builder(expression).type.integer.CopyFrom(ir_data.IntegerType())
     self.assertTrue(ir_util.is_constant(expression))
 
   def test_is_constant_boolean(self):
     self.assertTrue(ir_util.is_constant(_parse_expression("true")))
     expression = _parse_expression("true")
     # The type information should be ignored for constants like this one.
-    expression.type.boolean.CopyFrom(ir_data.BooleanType())
+    ir_data_utils.builder(expression).type.boolean.CopyFrom(ir_data.BooleanType())
     self.assertTrue(ir_util.is_constant(expression))
 
   def test_is_constant_enum(self):


### PR DESCRIPTION
This adds an `ir_data_utils.builder` wrapper that will be used to dynamically build up `ir_data` instances rather than the ad-hoc behavior of `ir_data` field access. For now this is a no-op and simply annotates sites that are mutating `ir_data` instances.

Part of #118.