### PR TITLE
Fixes `_make_source_location_tests()` build error.

### DIFF
--- a/compiler/front_end/module_ir_test.py
+++ b/compiler/front_end/module_ir_test.py
@@ -4102,8 +4102,8 @@ def _check_all_source_locations(proto, path="", min_start=None, max_end=None):
     if not proto.HasField(name):
       continue
     field_path = "{}{}".format(path, name)
-    if isinstance(spec, ir_pb2.Repeated):
-      if issubclass(spec.type, ir_pb2.Message):
+    if isinstance(spec, ir_data.Repeated):
+      if issubclass(spec.type, ir_data.Message):
         index = 0
         for i in getattr(proto, name):
           item_path = "{}[{}]".format(field_path, index)


### PR DESCRIPTION
It looks like there`ir_pb2` was still present in `module_ir_test.py` after #141 . This renames the last couple references to `ir_data`. Tests pass locally with this change.