### PR TITLE
Fix missing template parameters

### DIFF
--- a/runtime/cpp/emboss_arithmetic.h
+++ b/runtime/cpp/emboss_arithmetic.h
@@ -89,7 +89,7 @@ template <typename IntermediateT, typename ResultT, typename OperatorT,
           typename... ArgsT>
 inline constexpr Maybe<ResultT> MaybeDo(Maybe<ArgsT>... args) {
   return AllKnown(args...)
-             ? Maybe<ResultT>(static_cast<ResultT>(OperatorT::template Do(
+             ? Maybe<ResultT>(static_cast<ResultT>(OperatorT::template Do<>(
                    static_cast<IntermediateT>(args.ValueOrDefault())...)))
              : Maybe<ResultT>();
 }


### PR DESCRIPTION
Fix missing template parameters in MaybeDo. The latest version of clang throws an error without this fix.