### PR TITLE
Forward kwargs to emboss_cc_library

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -26,7 +26,7 @@ There is also a convenience macro, `emboss_cc_library()`, which creates an
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = [], enable_enum_traits = True):
+def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = [], enable_enum_traits = True, **kwargs):
     """Constructs a C++ library from an .emb file."""
     if len(srcs) != 1:
         fail(
@@ -39,6 +39,7 @@ def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = []
         srcs = srcs,
         deps = [dep + "_ir" for dep in deps],
         import_dirs = import_dirs,
+        **kwargs
     )
 
     cc_emboss_library(
@@ -46,6 +47,7 @@ def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = []
         deps = [":" + name + "_ir"],
         visibility = visibility,
         enable_enum_traits = enable_enum_traits,
+        **kwargs
     )
 
 # Full Starlark rules for emboss_library and cc_emboss_library.

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -108,6 +108,9 @@ emboss_cc_library(
     srcs = [
         "enum.emb",
     ],
+    # This tag is arbitrary, and exists to ensure you can pass atributes common
+    # to all build rules to the underlying rules.
+    tags = ["an_arbitrary_tag"],
 )
 
 emboss_cc_library(


### PR DESCRIPTION
Forwards kwargs to emboss_cc_library to fix https://github.com/google/emboss/issues/154.