### PR TITLE
Remove unused <ostream>

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -33,7 +33,6 @@
 #include <string.h>
 
 #include <algorithm>
-#include <ostream>
 #include <type_traits>
 #include <utility>
 


### PR DESCRIPTION
`<ostream>` isn't needed unless enum traits are being used, in that case it will be included by the files that need it. Removing this fixes a failure for targets that don't have `<ostream>` available.

Fixes: #156