### PR TITLE
Update set of supported alias-safe types

### DIFF
--- a/runtime/cpp/emboss_cpp_types.h
+++ b/runtime/cpp/emboss_cpp_types.h
@@ -17,6 +17,7 @@
 #define EMBOSS_RUNTIME_CPP_EMBOSS_CPP_TYPES_H_
 
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
@@ -77,21 +78,23 @@ struct LeastWidthInteger<8> final {
   using Signed = ::std::int8_t;
 };
 
-// IsChar<T>::value is true if T is a character type; i.e. const? volatile?
-// (signed|unsigned)? char.
+// IsAliasSafe<T>::value is true if T is an alias safe type; i.e. const?
+// volatile? (unsigned)? char | std::byte.
 template <typename T>
-struct IsChar {
+struct IsAliasSafe {
   // Note that 'char' is a distinct type from 'signed char' and 'unsigned char'.
   static constexpr bool value =
       ::std::is_same<char, typename ::std::remove_cv<T>::type>::value ||
-      ::std::is_same<unsigned char,
-                     typename ::std::remove_cv<T>::type>::value ||
-      ::std::is_same<signed char, typename ::std::remove_cv<T>::type>::value;
+      ::std::is_same<unsigned char, typename ::std::remove_cv<T>::type>::value
+#if __cplusplus >= 201703
+      || ::std::is_same<::std::byte, typename ::std::remove_cv<T>::type>::value
+#endif
+      ;
 };
 
 // The static member variable requires a definition.
 template <typename T>
-constexpr bool IsChar<T>::value;
+constexpr bool IsAliasSafe<T>::value;
 
 // AddSourceConst<SourceT, DestT>::Type is DestT's base type with const added if
 // SourceT is const.

--- a/runtime/cpp/test/emboss_cpp_types_test.cc
+++ b/runtime/cpp/test/emboss_cpp_types_test.cc
@@ -100,30 +100,37 @@ TEST(LeastWidthInteger, Types) {
       (::std::is_same<LeastWidthInteger<64>::Signed, ::std::int64_t>::value));
 }
 
-TEST(IsChar, CharTypes) {
-  EXPECT_TRUE(IsChar<char>::value);
-  EXPECT_TRUE(IsChar<unsigned char>::value);
-  EXPECT_TRUE(IsChar<signed char>::value);
-  EXPECT_TRUE(IsChar<const char>::value);
-  EXPECT_TRUE(IsChar<const unsigned char>::value);
-  EXPECT_TRUE(IsChar<const signed char>::value);
-  EXPECT_TRUE(IsChar<volatile char>::value);
-  EXPECT_TRUE(IsChar<volatile unsigned char>::value);
-  EXPECT_TRUE(IsChar<volatile signed char>::value);
-  EXPECT_TRUE(IsChar<const volatile char>::value);
-  EXPECT_TRUE(IsChar<const volatile unsigned char>::value);
-  EXPECT_TRUE(IsChar<const volatile signed char>::value);
+TEST(IsAliasSafe, CharTypes) {
+  EXPECT_TRUE(IsAliasSafe<char>::value);
+  EXPECT_TRUE(IsAliasSafe<unsigned char>::value);
+  EXPECT_TRUE(IsAliasSafe<const char>::value);
+  EXPECT_TRUE(IsAliasSafe<const unsigned char>::value);
+  EXPECT_TRUE(IsAliasSafe<volatile char>::value);
+  EXPECT_TRUE(IsAliasSafe<volatile unsigned char>::value);
+  EXPECT_TRUE(IsAliasSafe<const volatile char>::value);
+  EXPECT_TRUE(IsAliasSafe<const volatile unsigned char>::value);
+#if __cplusplus >= 201703
+  EXPECT_TRUE(IsAliasSafe<::std::byte>::value);
+  EXPECT_TRUE(IsAliasSafe<const ::std::byte>::value);
+  EXPECT_TRUE(IsAliasSafe<volatile ::std::byte>::value);
+  EXPECT_TRUE(IsAliasSafe<const volatile ::std::byte>::value);
+#endif
 }
 
-TEST(IsChar, NonCharTypes) {
+TEST(IsAliasSafe, NonCharTypes) {
   struct OneByte {
     char c;
   };
   EXPECT_EQ(1U, sizeof(OneByte));
-  EXPECT_FALSE(IsChar<int>::value);
-  EXPECT_FALSE(IsChar<unsigned>::value);
-  EXPECT_FALSE(IsChar<const int>::value);
-  EXPECT_FALSE(IsChar<OneByte>::value);
+  EXPECT_FALSE(IsAliasSafe<int>::value);
+  EXPECT_FALSE(IsAliasSafe<unsigned>::value);
+  EXPECT_FALSE(IsAliasSafe<const int>::value);
+  EXPECT_FALSE(IsAliasSafe<OneByte>::value);
+
+  EXPECT_FALSE(IsAliasSafe<signed char>::value);
+  EXPECT_FALSE(IsAliasSafe<const signed char>::value);
+  EXPECT_FALSE(IsAliasSafe<volatile signed char>::value);
+  EXPECT_FALSE(IsAliasSafe<const volatile signed char>::value);
 }
 
 TEST(AddSourceConst, AddSourceConst) {


### PR DESCRIPTION
Renames `IsChar` to `IsAliasSafe`, removes `signed char` as an alias safe type and adds in conditional support for `std::byte` as an anlias safe type if available.

Fixes: #116