### PR TITLE
Add Github action to run Bazel tests for every PR

### DIFF
--- a/.github/workflows/run-bazel-tests.yml
+++ b/.github/workflows/run-bazel-tests.yml
@@ -1,0 +1,14 @@
+name: Run Bazel tests
+on: [pull_request]
+
+jobs:
+  run-bazel-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.8.5
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+      - run: bazel test ...


### PR DESCRIPTION
This will ensure that all pull requests must pass all Bazel tests in the repository. Merging the pull request will be blocked until the tests are passing, and will re-run each time the pull request is synchronized or updated.