### PR TITLE
Explicitly define default ContiguousBuffer assign op

### DIFF
--- a/runtime/cpp/emboss_memory_util.h
+++ b/runtime/cpp/emboss_memory_util.h
@@ -411,9 +411,9 @@ class ContiguousBuffer final {
   // TODO(bolms): Update callers and remove this constructor.
   explicit ContiguousBuffer(::std::nullptr_t) : bytes_{nullptr}, size_{0} {}
 
-  // Implicitly constructs a ContiguousBuffer from an identical
-  // ContiguousBuffer.
+  // Implicitly construct or assign a ContiguousBuffer from a ContiguousBuffer.
   ContiguousBuffer(const ContiguousBuffer &other) = default;
+  ContiguousBuffer& operator=(const ContiguousBuffer& other) = default;
 
   // Explicitly construct a ContiguousBuffers from another, compatible
   // ContiguousBuffer.  A compatible ContiguousBuffer has an


### PR DESCRIPTION
Since code defines copy constructor it should also define the assignment operator (rule of three).

This also fixes #148.