### PR TITLE
Fix for Python 3.9

### DIFF
--- a/compiler/util/ir_data_fields.py
+++ b/compiler/util/ir_data_fields.py
@@ -287,7 +287,7 @@ def _field_specs(cls: type[IrDataT]) -> Mapping[str, FieldSpec]:
   return result
 
 
-def field_specs(obj: IrDataT | type[IrDataT]) -> Mapping[str, FieldSpec]:
+def field_specs(obj: Union[IrDataT, type[IrDataT]]) -> Mapping[str, FieldSpec]:
   """Retrieves the fields specs for the the give data type.
 
   The results of this method are cached to reduce lookup overhead.
@@ -356,7 +356,7 @@ def _copy(ir: IrDataT) -> IrDataT:
   return type(ir)(**_copy_set_fields(ir))  # type: ignore[misc]
 
 
-def copy(ir: IrDataT) -> IrDataT | None:
+def copy(ir: IrDataT) -> Optional[IrDataT]:
   """Creates a copy of the given IR data class"""
   if not ir:
     return None


### PR DESCRIPTION
Python 3.9 is still supported, but Python 3.9 does not support type unions with the `|` operator. This change removes these in favor of `Union[...]` or `Optional[...]` as appropriate.

Confirmed all tests pass using Python 3.9