### PR TITLE
Add `visibility` to the Bazel rule for the Emboss IR.

### DIFF
--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -26,7 +26,7 @@ There is also a convenience macro, `emboss_cc_library()`, which creates an
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 
-def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = [], enable_enum_traits = True, **kwargs):
+def emboss_cc_library(name, srcs, deps = [], import_dirs = [], enable_enum_traits = True, **kwargs):
     """Constructs a C++ library from an .emb file."""
     if len(srcs) != 1:
         fail(
@@ -45,7 +45,6 @@ def emboss_cc_library(name, srcs, deps = [], visibility = None, import_dirs = []
     cc_emboss_library(
         name = name,
         deps = [":" + name + "_ir"],
-        visibility = visibility,
         enable_enum_traits = enable_enum_traits,
         **kwargs
     )


### PR DESCRIPTION
This is accomplished by allowing `visibility` to be picked up by `kwargs`.