### PR TITLE
Cast to ValueType before ValueIsOk check

### DIFF
--- a/runtime/cpp/emboss_prelude.h
+++ b/runtime/cpp/emboss_prelude.h
@@ -267,7 +267,7 @@ class UIntView final {
            static_cast</**/ ::std::uint64_t>(value) <=
                ((static_cast<ValueType>(1) << (Parameters::kBits - 1)) << 1) -
                    1 &&
-           Parameters::ValueIsOk(value);
+           Parameters::ValueIsOk(static_cast<ValueType>(value));
   }
   void UncheckedWrite(ValueType value) const {
     buffer_.UncheckedWriteUInt(value);
@@ -429,7 +429,8 @@ class IntView final {
                     : ((static_cast<ValueType>(1) << (Parameters::kBits - 2)) -
                        1) * 2 +
                           1) &&
-           Parameters::ValueIsOk(value);
+           Parameters::ValueIsOk(static_cast<ValueType>(value));
+
   }
 
   void UncheckedWrite(ValueType value) const {


### PR DESCRIPTION
This allows using a larger backing value type to assign a UInt or Int value when the value itself fits within the range of the internal value type. Previously this would fail to compile if `-Wshorten-64-to-32` was specified when building with `clang`:

```
UIntView<FixedSizeViewParameters<16, AllValuesAreOk>> view;
size_t value = 200;
view.TryToWrite(value);
```

Fixes #185