### PR TITLE
Restructure ACTION and GOTO tables.

### DIFF
--- a/compiler/front_end/lr1.py
+++ b/compiler/front_end/lr1.py
@@ -652,7 +652,7 @@ class Parser(object):
                 )
                 return ParseResult(stack[-1][1], None)
             elif isinstance(next_action, Reduce):
-                # Reduce means that there is a c][plete production on the stack, and
+                # Reduce means that there is a complete production on the stack, and
                 # that the next symbol implies that the completed production is the
                 # correct production.
                 #


### PR DESCRIPTION
With this change, the `Parser.action` and `.goto` tables are now 2-layer hash tables, using states as the keys for the outer tables and symbols as the keys for the inner tables.  Functionally, this means that `action[state, symbol]` becomes `action[state][symbol]`, and likewise for `goto`.

This also allows the `expected` table to be eliminated, as it can be quickly computed from `action[state]` when needed.

This goal of this change is to have a more compact representation for issue #193: by structuring the tables this way, state numbers do not need to be repeated in the serialized output.  Eliminating `expected` also provides a modest savings.  The total savings is approximately 55%, going from 4.3MB without this change to 1.9MB with this change.