### PR TITLE
Add `--debug-stop-before-step` flag.

### DIFF
--- a/compiler/front_end/emboss_front_end.py
+++ b/compiler/front_end/emboss_front_end.py
@@ -56,6 +56,12 @@ def _parse_command_line(argv):
         "before symbol resolution.",
     )
     parser.add_argument(
+        "--debug-stop-before-step",
+        type=str,
+        nargs=1,
+        help="Stop processing before the specified step.",
+    )
+    parser.add_argument(
         "--debug-show-full-ir",
         action="store_true",
         help="Show the final IR of the main input file.",
@@ -146,7 +152,7 @@ def _find_in_dirs_and_read(import_dirs):
     return _find_and_read
 
 
-def parse_and_log_errors(input_file, import_dirs, color_output):
+def parse_and_log_errors(input_file, import_dirs, color_output, stop_before_step=None):
     """Fully parses an .emb and logs any errors.
 
     Arguments:
@@ -158,7 +164,7 @@ def parse_and_log_errors(input_file, import_dirs, color_output):
       (ir, debug_info, errors)
     """
     ir, debug_info, errors = glue.parse_emboss_file(
-        input_file, _find_in_dirs_and_read(import_dirs)
+        input_file, _find_in_dirs_and_read(import_dirs), stop_before_step=stop_before_step
     )
     if errors:
         _show_errors(errors, ir, color_output)
@@ -168,7 +174,7 @@ def parse_and_log_errors(input_file, import_dirs, color_output):
 
 def main(flags):
     ir, debug_info, errors = parse_and_log_errors(
-        flags.input_file[0], flags.import_dirs, flags.color_output
+        flags.input_file[0], flags.import_dirs, flags.color_output, stop_before_step=flags.debug_stop_before_step[0],
     )
     if errors:
         return 1

--- a/compiler/front_end/emboss_front_end.py
+++ b/compiler/front_end/emboss_front_end.py
@@ -164,7 +164,9 @@ def parse_and_log_errors(input_file, import_dirs, color_output, stop_before_step
       (ir, debug_info, errors)
     """
     ir, debug_info, errors = glue.parse_emboss_file(
-        input_file, _find_in_dirs_and_read(import_dirs), stop_before_step=stop_before_step
+        input_file,
+        _find_in_dirs_and_read(import_dirs),
+        stop_before_step=stop_before_step,
     )
     if errors:
         _show_errors(errors, ir, color_output)
@@ -174,7 +176,10 @@ def parse_and_log_errors(input_file, import_dirs, color_output, stop_before_step
 
 def main(flags):
     ir, debug_info, errors = parse_and_log_errors(
-        flags.input_file[0], flags.import_dirs, flags.color_output, stop_before_step=flags.debug_stop_before_step[0],
+        flags.input_file[0],
+        flags.import_dirs,
+        flags.color_output,
+        stop_before_step=flags.debug_stop_before_step[0],
     )
     if errors:
         return 1

--- a/compiler/front_end/emboss_front_end.py
+++ b/compiler/front_end/emboss_front_end.py
@@ -58,7 +58,6 @@ def _parse_command_line(argv):
     parser.add_argument(
         "--debug-stop-before-step",
         type=str,
-        nargs=1,
         help="Stop processing before the specified step.",
     )
     parser.add_argument(
@@ -179,7 +178,7 @@ def main(flags):
         flags.input_file[0],
         flags.import_dirs,
         flags.color_output,
-        stop_before_step=flags.debug_stop_before_step[0],
+        stop_before_step=flags.debug_stop_before_step,
     )
     if errors:
         return 1

--- a/compiler/front_end/glue.py
+++ b/compiler/front_end/glue.py
@@ -325,7 +325,10 @@ def process_ir(ir, stop_before_step):
         write_inference.set_write_methods,
     )
     valid_step_names = [f.__name__ for f in passes]
-    assert stop_before_step in [None] + valid_step_names, f"Bad value '{stop_before_step}' for stop_before_step.  Valid values: " + " ".join(valid_step_names)
+    assert stop_before_step in [None] + valid_step_names, (
+        f"Bad value '{stop_before_step}' for stop_before_step.  Valid values: "
+        + " ".join(valid_step_names)
+    )
     # Some parts of the IR are synthesized from "natural" parts of the IR, before
     # the natural parts have been fully error checked.  Because of this, the
     # synthesized parts can have errors; in a couple of cases, they can have

--- a/compiler/front_end/glue.py
+++ b/compiler/front_end/glue.py
@@ -19,6 +19,7 @@ and returns an IR or formatted error message.
 """
 
 import collections
+import sys
 
 from compiler.front_end import attribute_checker
 from compiler.front_end import constraints
@@ -323,9 +324,8 @@ def process_ir(ir, stop_before_step):
         constraints.check_constraints,
         write_inference.set_write_methods,
     )
-    assert stop_before_step in [None] + [
-        f.__name__ for f in passes
-    ], "Bad value for stop_before_step."
+    valid_step_names = [f.__name__ for f in passes]
+    assert stop_before_step in [None] + valid_step_names, f"Bad value '{stop_before_step}' for stop_before_step.  Valid values: " + " ".join(valid_step_names)
     # Some parts of the IR are synthesized from "natural" parts of the IR, before
     # the natural parts have been fully error checked.  Because of this, the
     # synthesized parts can have errors; in a couple of cases, they can have
@@ -371,7 +371,9 @@ def process_ir(ir, stop_before_step):
     deferred_errors = []
     for function in passes:
         if stop_before_step == function.__name__:
+            print("Stopping before", stop_before_step, file=sys.stderr)
             return (ir, [])
+        print("Running", function.__name__, file=sys.stderr)
         errors, hidden_errors = error.split_errors(function(ir))
         if errors:
             return (None, errors)

--- a/compiler/front_end/glue.py
+++ b/compiler/front_end/glue.py
@@ -374,9 +374,7 @@ def process_ir(ir, stop_before_step):
     deferred_errors = []
     for function in passes:
         if stop_before_step == function.__name__:
-            print("Stopping before", stop_before_step, file=sys.stderr)
             return (ir, [])
-        print("Running", function.__name__, file=sys.stderr)
         errors, hidden_errors = error.split_errors(function(ir))
         if errors:
             return (None, errors)


### PR DESCRIPTION
This exposes the existing `stop_before_step` functionality that is used in unit tests through the command line, which allows the IR to be inspected/analyzed.

This is a pure debug option.