### PR TITLE
Add test profiles that disable all `EMBOSS_CHECK`s.

### DIFF
--- a/compiler/back_end/cpp/build_defs.bzl
+++ b/compiler/back_end/cpp/build_defs.bzl
@@ -20,14 +20,26 @@ def emboss_cc_test(name, copts = None, no_w_sign_compare = False, **kwargs):
     """Generates cc_test rules with and without -DEMBOSS_NO_OPTIMIZATIONS."""
     native.cc_test(
         name = name,
-        copts = ["-DEMBOSS_FORCE_ALL_CHECKS"] + (copts or []),
+        copts = copts or [],
         **kwargs
     )
     native.cc_test(
         name = name + "_no_opts",
         copts = [
             "-DEMBOSS_NO_OPTIMIZATIONS",
-            "-DEMBOSS_FORCE_ALL_CHECKS",
+        ] + ([] if no_w_sign_compare else ["-Wsign-compare"]) + (copts or []),
+        **kwargs
+    )
+    native.cc_test(
+        name = name + "_no_checks",
+        copts = ["-DEMBOSS_SKIP_CHECKS"] + (copts or []),
+        **kwargs
+    )
+    native.cc_test(
+        name = name + "_no_checks_no_opts",
+        copts = [
+            "-DEMBOSS_NO_OPTIMIZATIONS",
+            "-DEMBOSS_SKIP_CHECKS",
         ] + ([] if no_w_sign_compare else ["-Wsign-compare"]) + (copts or []),
         **kwargs
     )

--- a/runtime/cpp/emboss_defines.h
+++ b/runtime/cpp/emboss_defines.h
@@ -66,9 +66,17 @@
 //
 // By default, checks are only enabled on non-NDEBUG builds.  (Note that all
 // translation units MUST be built with the same value of NDEBUG!)
+//
+// The EMBOSS_SKIP_CHECKS parameter allows all CHECKs to be compiled out
+// without -DNDEBUG; this is useful for testing.
 #if !defined(EMBOSS_CHECK)
+#if EMBOSS_SKIP_CHECKS
+#define EMBOSS_CHECK(x) ((void)0)
+#define EMBOSS_CHECK_ABORTS false
+#else
 #define EMBOSS_CHECK(x) assert((x))
 #define EMBOSS_CHECK_ABORTS (!(NDEBUG))
+#endif
 #endif  // !defined(EMBOSS_CHECK)
 
 #if !defined(EMBOSS_CHECK_ABORTS)


### PR DESCRIPTION
This catches cases where C++ code inadvertently includes side effects inside of an `EMBOSS_CHECK`; the default `EMBOSS_CHECK` uses `assert`, which will be omitted when `NDEBUG` is defined.

Also remove the `EMBOSS_FORCE_ALL_CHECKS` define, which is a holdover from the glog-based `EMBOSS_DCHECK` implementation in the original, Google-internal implementation.