### PR TITLE
Fix tests under `bazel test -c opt`.

### DIFF
--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         cpp-compiler: ["clang", "gcc"]
+        options: ["-c opt", ""]
     steps:
       - uses: actions/checkout@v4
       - uses: bazel-contrib/setup-bazel@0.8.5
@@ -16,7 +17,7 @@ jobs:
           disk-cache: "verify-pr:run-bazel-tests:${{ matrix.cpp-compiler }}"
           repository-cache: true
       - run: echo "CC=${{ matrix.cpp-compiler }}" >> $GITHUB_ENV
-      - run: bazel test ...
+      - run: bazel test ${{ matrix.options }} ...
   check-formatting:
     name: "Check Python formatting"
     runs-on: ubuntu-latest

--- a/runtime/cpp/emboss_defines.h
+++ b/runtime/cpp/emboss_defines.h
@@ -153,6 +153,27 @@
                   static_cast</**/ ::std::uintptr_t>((offset)))
 #endif  // !defined(EMBOSS_CHECK_POINTER_ALIGNMENT)
 
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115033
+//
+// This affects Emboss: without the fix in the appropriate bug, we get a
+// miscompilation for some Emboss code, including some unit tests.
+//
+// It is not known whether the workaround on the Emboss side is complete, so
+// the recommendation is to move to a version of GCC that is not affected.
+// However, changing toolchains can be difficult, so we do provide a
+// workaround.
+#if !defined(EMBOSS_GCC_BUG_115033)
+#if defined(__clang__)
+#define EMBOSS_GCC_BUG_115033 0
+#elif __GNUC__ >= 12 && __GNUC__ <= 13
+#define EMBOSS_GCC_BUG_115033 1
+#elif __GNUC__ == 14 && __GNUC_MINOR__ < 2
+#define EMBOSS_GCC_BUG_115033 1
+#else
+#define EMBOSS_GCC_BUG_115033 0
+#endif
+#endif
+
 // EMBOSS_NO_OPTIMIZATIONS is used to turn off all system-specific
 // optimizations.  This is mostly intended for testing, but could be used if
 // optimizations are causing problems.


### PR DESCRIPTION
With certain versions of GCC, `bazel test -c opt ...` failed, apparently due to a compiler bug.

This change:

1.  Adds a workaround for the GCC bug.
2.  Enables the workaround on versions of GCC known to have the bug.
3.  Documents the bug (in comments).
4.  Enables testing with `-c opt` as part of the commit hook.

Note that the versions covered by #2 are a little wider than may be technically necessary.  As of the time of writing, this affects all released versions of GCC from 12.1 through 14.1, but the GCC fix has been backported to the 12.X and 13.X branches.  It may be possible to reduce the workaround's scope once those are released.