### PR TITLE
Add `alignas` specifier to buffer in explicit alignment test.

### DIFF
--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -17,7 +17,7 @@ jobs:
           disk-cache: "verify-pr:run-bazel-tests:${{ matrix.cpp-compiler }}"
           repository-cache: true
       - run: echo "CC=${{ matrix.cpp-compiler }}" >> $GITHUB_ENV
-      - run: bazel test ${{ matrix.options }} ...
+      - run: bazel test --test_output=errors ${{ matrix.options }} ...
   check-formatting:
     name: "Check Python formatting"
     runs-on: ubuntu-latest

--- a/compiler/back_end/cpp/testcode/auto_array_size_test.cc
+++ b/compiler/back_end/cpp/testcode/auto_array_size_test.cc
@@ -306,7 +306,7 @@ TEST(AutoSizeView, CanCopyFrom) {
   auto source = MakeAlignedAutoSizeView<const ::std::uint8_t, 8>(
       kAutoSize, sizeof kAutoSize);
 
-  ::std::array</**/ ::std::uint8_t, sizeof kAutoSize> buf = {0};
+  alignas(8) ::std::array</**/ ::std::uint8_t, sizeof kAutoSize> buf = {0};
   auto dest =
       MakeAlignedAutoSizeView</**/ ::std::uint8_t, 8>(buf.data(), buf.size());
 


### PR DESCRIPTION
This fixes the `clang` test failures.

Also update workflow to emit test logs on failure.