### PR TITLE
Noncontiguous View Support

### DIFF
--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -99,6 +99,23 @@ emboss_cc_test(
     ],
     deps = [
         "//testdata:alignments_emboss",
+        "//runtime/cpp/test/util:noncontiguous_container",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+emboss_cc_test(
+    name = "iterator_view_integration_test",
+    srcs = [
+        "testcode/iterator_view_integration_test.cc",
+    ],
+    deps = [
+        "//testdata:alignments_emboss",
+        "//testdata:condition_emboss",
+        "//testdata:dynamic_size_emboss",
+        "//testdata:uint_sizes_emboss",
+        "//testdata:virtual_field_emboss",
+        "//runtime/cpp/test/util:noncontiguous_container",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -250,6 +250,40 @@ MakeAligned${name}View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline Generic${name}View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+Make${name}View(${constructor_parameters} Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return Generic${name}View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ${forwarded_parameters} ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGeneric${name}View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline Generic${name}View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+Make${name}View(${constructor_parameters} Container &&emboss_reserved_local_container) {
+  return Generic${name}View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ${forwarded_parameters} ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 // ** struct_text_stream ** ////////////////////////////////////////////////////
   template <class Stream>
   bool UpdateFromTextStream(Stream *emboss_reserved_local_stream) const {

--- a/compiler/back_end/cpp/testcode/iterator_view_integration_test.cc
+++ b/compiler/back_end/cpp/testcode/iterator_view_integration_test.cc
@@ -1,0 +1,225 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <vector>
+
+#include "runtime/cpp/test/util/noncontiguous_container.h"
+#include "testdata/alignments.emb.h"
+#include "testdata/condition.emb.h"
+#include "testdata/dynamic_size.emb.h"
+#include "testdata/uint_sizes.emb.h"
+#include "testdata/virtual_field.emb.h"
+
+namespace emboss {
+namespace test {
+namespace {
+
+template <typename CharT>
+void TestMakeAlignmentsViewIntegration() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x11), ByteT(0x22)},
+      {ByteT(0x33), ByteT(0x44), ByteT(0x55)},
+      {ByteT(0x66), ByteT(0x77), ByteT(0x88)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00), ByteT(0x00)}};
+
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  auto view = MakeAlignmentsView(container);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_EQ(view.SizeInBytes(), 28U);
+
+  EXPECT_EQ(view.zero_offset().dummy().Read(), 0x11223344U);
+  EXPECT_EQ(view.three_offset().dummy().Read(), 0x44556677U);
+  EXPECT_EQ(view.four_offset().dummy().Read(), 0x55667788U);
+}
+
+TEST(IteratorViewIntegrationTest, MakeAlignmentsView) {
+  TestMakeAlignmentsViewIntegration<const char>();
+  TestMakeAlignmentsViewIntegration<char>();
+  TestMakeAlignmentsViewIntegration<const unsigned char>();
+  TestMakeAlignmentsViewIntegration<unsigned char>();
+#if __cplusplus >= 201703L
+  TestMakeAlignmentsViewIntegration<const std::byte>();
+  TestMakeAlignmentsViewIntegration<std::byte>();
+#endif
+}
+
+// ---------------------------------------------------------
+// BasicConditional from condition.emb (LittleEndian)
+// 0 [+1] UInt x; if x == 0: 1 [+1] UInt xc
+// ---------------------------------------------------------
+
+template <typename CharT>
+void TestBasicConditionalViewIntegration() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x00)},  // x == 0
+      {ByteT(0xAA)}   // xc == 0xAA
+  };
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  auto view = MakeBasicConditionalView(container);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_EQ(view.SizeInBytes(), 2U);
+  EXPECT_EQ(view.x().Read(), 0U);
+  EXPECT_EQ(view.xc().Read(), 0xAAU);
+
+  std::vector<std::vector<ByteT>> chunks2 = {
+      {ByteT(0x01)},  // x == 1
+  };
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container2(chunks2);
+  auto view2 = MakeBasicConditionalView(container2);
+  EXPECT_TRUE(view2.Ok());
+  EXPECT_EQ(view2.SizeInBytes(), 1U);
+
+  std::vector<std::vector<ByteT>> chunks_fail = {
+      {ByteT(0x00)},  // x == 0
+  };
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container_fail(
+      chunks_fail);
+  auto view_fail = MakeBasicConditionalView(container_fail);
+  EXPECT_FALSE(view_fail.IsComplete());
+}
+
+TEST(IteratorViewIntegrationTest, BasicConditional) {
+  TestBasicConditionalViewIntegration<char>();
+  TestBasicConditionalViewIntegration<const char>();
+  TestBasicConditionalViewIntegration<unsigned char>();
+  TestBasicConditionalViewIntegration<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestBasicConditionalViewIntegration<std::byte>();
+  TestBasicConditionalViewIntegration<const std::byte>();
+#endif
+}
+
+// ---------------------------------------------------------
+// AlternatingEndianSizes from uint_sizes.emb
+// Mixture of LittleEndian and BigEndian
+// ---------------------------------------------------------
+template <typename CharT>
+void TestAlternatingEndianSizesViewIntegration() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x11)},               // one_byte (BigEndian)
+      {ByteT(0x22), ByteT(0x33)},  // two_byte (LittleEndian) = 0x3322
+      {ByteT(0x44)},               // split...
+      {ByteT(0x55), ByteT(0x66)},  // three_byte (BigEndian) = 0x445566
+      {ByteT(0x77), ByteT(0x88), ByteT(0x99),
+       ByteT(0xAA)}  // four_byte (LittleEndian) = 0xAA998877
+  };
+
+  // Adding the rest to reach 36 bytes (8 fields)
+  chunks.push_back(std::vector<ByteT>(26));
+
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  auto view = MakeAlternatingEndianSizesView(container);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_EQ(view.one_byte().Read(), 0x11U);
+  EXPECT_EQ(view.two_byte().Read(), 0x3322U);
+  EXPECT_EQ(view.three_byte().Read(), 0x445566U);
+  EXPECT_EQ(view.four_byte().Read(), 0xAA998877U);
+}
+
+TEST(IteratorViewIntegrationTest, AlternatingEndianSizes) {
+  TestAlternatingEndianSizesViewIntegration<char>();
+  TestAlternatingEndianSizesViewIntegration<const char>();
+  TestAlternatingEndianSizesViewIntegration<unsigned char>();
+  TestAlternatingEndianSizesViewIntegration<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestAlternatingEndianSizesViewIntegration<std::byte>();
+  TestAlternatingEndianSizesViewIntegration<const std::byte>();
+#endif
+}
+
+// ---------------------------------------------------------
+// Message from dynamic_size.emb
+// struct Message:
+//   0   [+1]    UInt         header_length (h)
+//   1   [+1]    UInt         message_length (m)
+//   2   [+h-2]  UInt:8[h-2]  padding
+//   h   [+m]    UInt:8[m]    message
+//   h+m [+4]    UInt         crc32
+// ---------------------------------------------------------
+template <typename CharT>
+void TestMessageDynamicSizeIntegration() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  // h = 4, m = 3
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(4)},                                           // header_length
+      {ByteT(3)},                                           // message_length
+      {ByteT(0x00), ByteT(0x00)},                           // padding
+      {ByteT(0xAA), ByteT(0xBB)},                           // message byte 0, 1
+      {ByteT(0xCC)},                                        // message byte 2
+      {ByteT(0x11), ByteT(0x22), ByteT(0x33), ByteT(0x44)}  // crc32
+  };
+
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  auto view = MakeMessageView(container);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_EQ(view.SizeInBytes(), 11U);
+  EXPECT_EQ(view.header_length().Read(), 4U);
+  EXPECT_EQ(view.message_length().Read(), 3U);
+
+  EXPECT_EQ(view.message()[0].Read(), 0xAAU);
+  EXPECT_EQ(view.message()[1].Read(), 0xBBU);
+  EXPECT_EQ(view.message()[2].Read(), 0xCCU);
+
+  EXPECT_EQ(view.crc32().Read(), 0x44332211U);  // Little endian
+}
+
+TEST(IteratorViewIntegrationTest, MessageDynamicSize) {
+  TestMessageDynamicSizeIntegration<char>();
+  TestMessageDynamicSizeIntegration<const char>();
+  TestMessageDynamicSizeIntegration<unsigned char>();
+  TestMessageDynamicSizeIntegration<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestMessageDynamicSizeIntegration<std::byte>();
+  TestMessageDynamicSizeIntegration<const std::byte>();
+#endif
+}
+
+// ---------------------------------------------------------
+// UsesExternalSize
+// ---------------------------------------------------------
+template <typename CharT>
+void TestUsesExternalSizeIntegration() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x11), ByteT(0x22), ByteT(0x33), ByteT(0x44)},
+      {ByteT(0x55), ByteT(0x66), ByteT(0x77), ByteT(0x88)},
+  };
+
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  auto view = MakeUsesExternalSizeView(container);
+  EXPECT_TRUE(view.Ok());
+  EXPECT_EQ(view.x().value().Read(), 0x44332211U);
+  EXPECT_EQ(view.y().value().Read(), 0x88776655U);
+}
+
+TEST(IteratorViewIntegrationTest, UsesExternalSize) {
+  TestUsesExternalSizeIntegration<char>();
+  TestUsesExternalSizeIntegration<const char>();
+  TestUsesExternalSizeIntegration<unsigned char>();
+  TestUsesExternalSizeIntegration<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestUsesExternalSizeIntegration<std::byte>();
+  TestUsesExternalSizeIntegration<const std::byte>();
+#endif
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace emboss

--- a/runtime/cpp/emboss_memory_util.h
+++ b/runtime/cpp/emboss_memory_util.h
@@ -47,31 +47,29 @@ struct MemoryAccessor {
   using ChainedAccessor =
       MemoryAccessor<CharT, kAlignment / 2, kOffset % (kAlignment / 2), kBits>;
   using Unsigned = typename LeastWidthInteger<kBits>::Unsigned;
-  static inline Unsigned ReadLittleEndianUInt(const CharT *bytes) {
+
+  static inline Unsigned ReadLittleEndianUInt(const CharT* bytes) {
     return ChainedAccessor::ReadLittleEndianUInt(bytes);
   }
-  static inline void WriteLittleEndianUInt(CharT *bytes, Unsigned value) {
+
+  static inline void WriteLittleEndianUInt(CharT* bytes, Unsigned value) {
     ChainedAccessor::WriteLittleEndianUInt(bytes, value);
   }
-  static inline Unsigned ReadBigEndianUInt(const CharT *bytes) {
+
+  static inline Unsigned ReadBigEndianUInt(const CharT* bytes) {
     return ChainedAccessor::ReadBigEndianUInt(bytes);
   }
-  static inline void WriteBigEndianUInt(CharT *bytes, Unsigned value) {
+
+  static inline void WriteBigEndianUInt(CharT* bytes, Unsigned value) {
     ChainedAccessor::WriteBigEndianUInt(bytes, value);
   }
 };
 
-// The least-aligned case for MemoryAccessor is 8-bit alignment, and the default
-// version of MemoryAccessor will devolve to this one if there is no more
-// specific override.
-//
-// If the system byte order is known, then these routines can use memcpy and
-// (possibly) a byte swap; otherwise they can read individual bytes and
-// shift+or them together in the appropriate order.  I (bolms@) haven't found a
-// compiler that will optimize the multiple reads, shifts, and ors into a single
-// read, so the memcpy version is *much* faster for 32-bit and larger reads.
+// UnalignedAccessor provides generic, iterator-compatible read and write
+// implementations for unaligned data. It uses std::copy_n to safely handle
+// data movement and byte reordering across contiguous or fragmented storage.
 template <typename CharT, ::std::size_t kBits>
-struct MemoryAccessor<CharT, 1, 0, kBits> {
+struct UnalignedAccessor {
   static_assert(kBits % 8 == 0,
                 "MemoryAccessor can only read and write whole-byte values.");
   static_assert(IsAliasSafe<CharT>::value,
@@ -80,32 +78,65 @@ struct MemoryAccessor<CharT, 1, 0, kBits> {
   using Unsigned = typename LeastWidthInteger<kBits>::Unsigned;
 
 #if defined(EMBOSS_LITTLE_ENDIAN_TO_NATIVE)
-  static inline Unsigned ReadLittleEndianUInt(const CharT *bytes) {
+  template <typename Iterator>
+  static inline Unsigned ReadLittleEndianUInt(Iterator bytes) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     Unsigned result = 0;
-    ::std::memcpy(&result, bytes, kBits / 8);
+    auto dest =
+        reinterpret_cast<typename ::std::remove_cv<CharT>::type*>(&result);
+    ::std::copy_n(bytes, kBits / 8, dest);
     return EMBOSS_LITTLE_ENDIAN_TO_NATIVE(result);
   }
 #else
-  static inline Unsigned ReadLittleEndianUInt(const CharT *bytes) {
+  template <typename Iterator>
+  static inline Unsigned ReadLittleEndianUInt(Iterator bytes) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     Unsigned result = 0;
-    for (decltype(kBits) i = 0; i < kBits / 8; ++i) {
-      result |=
-          static_cast<Unsigned>(static_cast</**/ ::std::uint8_t>(bytes[i]))
-          << i * 8;
+    auto it = bytes;
+    for (decltype(kBits) i = 0; i < kBits / 8; ++i, ++it) {
+      result |= static_cast<Unsigned>(static_cast</**/ ::std::uint8_t>(*it))
+                << i * 8;
     }
     return result;
   }
 #endif
 
 #if defined(EMBOSS_NATIVE_TO_LITTLE_ENDIAN)
-  static inline void WriteLittleEndianUInt(CharT *bytes, Unsigned value) {
+  template <typename Iterator>
+  static inline void WriteLittleEndianUInt(Iterator bytes, Unsigned value) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     value = EMBOSS_NATIVE_TO_LITTLE_ENDIAN(value);
-    ::std::memcpy(bytes, &value, kBits / 8);
+    auto src =
+        reinterpret_cast<const typename ::std::remove_cv<CharT>::type*>(&value);
+    ::std::copy_n(src, kBits / 8, bytes);
   }
 #else
-  static inline void WriteLittleEndianUInt(CharT *bytes, Unsigned value) {
-    for (decltype(kBits) i = 0; i < kBits / 8; ++i) {
-      bytes[i] = static_cast<CharT>(static_cast</**/ ::std::uint8_t>(value));
+  template <typename Iterator>
+  static inline void WriteLittleEndianUInt(Iterator bytes, Unsigned value) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
+    auto it = bytes;
+    for (decltype(kBits) i = 0; i < kBits / 8; ++i, ++it) {
+      *it = static_cast<DereferenceT>(static_cast</**/ ::std::uint8_t>(value));
       if (sizeof value > 1) {
         // Shifting an 8-bit type by 8 bits is undefined behavior, so skip this
         // step for uint8_t.
@@ -116,7 +147,14 @@ struct MemoryAccessor<CharT, 1, 0, kBits> {
 #endif
 
 #if defined(EMBOSS_BIG_ENDIAN_TO_NATIVE)
-  static inline Unsigned ReadBigEndianUInt(const CharT *bytes) {
+  template <typename Iterator>
+  static inline Unsigned ReadBigEndianUInt(Iterator bytes) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     Unsigned result = 0;
     // When a big-endian source integer is smaller than the result, the source
     // bytes must be copied into the final bytes of the destination.  This is
@@ -160,35 +198,59 @@ struct MemoryAccessor<CharT, 1, 0, kBits> {
     // +--------+--------+--------+--------+
     // | 0x00   | 0x11   | 0x22   | 0x33   |
     // +--------+--------+--------+--------+
-    ::std::memcpy(reinterpret_cast<char *>(&result) + sizeof result - kBits / 8,
-                  bytes, kBits / 8);
+    auto dest =
+        reinterpret_cast<typename ::std::remove_cv<CharT>::type*>(&result) +
+        sizeof(result) - kBits / 8;
+    ::std::copy_n(bytes, kBits / 8, dest);
     result = EMBOSS_BIG_ENDIAN_TO_NATIVE(result);
     return result;
   }
 #else
-  static inline Unsigned ReadBigEndianUInt(const CharT *bytes) {
+  template <typename Iterator>
+  static inline Unsigned ReadBigEndianUInt(Iterator bytes) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     Unsigned result = 0;
-    for (decltype(kBits) i = 0; i < kBits / 8; ++i) {
-      result |=
-          static_cast<Unsigned>(static_cast</**/ ::std::uint8_t>(bytes[i]))
-          << (kBits - 8 - i * 8);
+    auto it = bytes;
+    for (decltype(kBits) i = 0; i < kBits / 8; ++i, ++it) {
+      result |= static_cast<Unsigned>(static_cast</**/ ::std::uint8_t>(*it))
+                << (kBits - 8 - i * 8);
     }
     return result;
   }
 #endif
 
 #if defined(EMBOSS_NATIVE_TO_BIG_ENDIAN)
-  static inline void WriteBigEndianUInt(CharT *bytes, Unsigned value) {
+  template <typename Iterator>
+  static inline void WriteBigEndianUInt(Iterator bytes, Unsigned value) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
     value = EMBOSS_NATIVE_TO_BIG_ENDIAN(value);
-    ::std::memcpy(bytes,
-                  reinterpret_cast<char *>(&value) + sizeof value - kBits / 8,
-                  kBits / 8);
+    auto src = reinterpret_cast<const typename ::std::remove_cv<CharT>::type*>(
+                   &value) +
+               sizeof(value) - kBits / 8;
+    ::std::copy_n(src, kBits / 8, bytes);
   }
 #else
-  static inline void WriteBigEndianUInt(CharT *bytes, Unsigned value) {
-    for (decltype(kBits) i = 0; i < kBits / 8; ++i) {
-      bytes[kBits / 8 - 1 - i] =
-          static_cast<CharT>(static_cast</**/ ::std::uint8_t>(value));
+  template <typename Iterator>
+  static inline void WriteBigEndianUInt(Iterator bytes, Unsigned value) {
+    using DereferenceT = typename ::std::remove_cv<
+        typename ::std::remove_reference<decltype(*bytes)>::type>::type;
+    static_assert(
+        ::std::is_same<DereferenceT,
+                       typename ::std::remove_cv<CharT>::type>::value,
+        "UnalignedAccessor Iterator underlying type must match CharT.");
+    auto it = bytes + (kBits / 8 - 1);
+    for (decltype(kBits) i = 0; i < kBits / 8; ++i, --it) {
+      *it = static_cast<DereferenceT>(static_cast</**/ ::std::uint8_t>(value));
       if (sizeof value > 1) {
         // Shifting an 8-bit type by 8 bits is undefined behavior, so skip this
         // step for uint8_t.
@@ -197,6 +259,41 @@ struct MemoryAccessor<CharT, 1, 0, kBits> {
     }
   }
 #endif
+};
+
+// The least-aligned case for MemoryAccessor is 8-bit alignment, and the default
+// version of MemoryAccessor will devolve to this one if there is no more
+// specific override.
+//
+// If the system byte order is known, then these routines can use memcpy and
+// (possibly) a byte swap; otherwise they can read individual bytes and
+// shift+or them together in the appropriate order.  I (bolms@) haven't found a
+// compiler that will optimize the multiple reads, shifts, and ors into a single
+// read, so the memcpy version is *much* faster for 32-bit and larger reads.
+template <typename CharT, ::std::size_t kBits>
+struct MemoryAccessor<CharT, 1, 0, kBits> {
+  static_assert(kBits % 8 == 0,
+                "MemoryAccessor can only read and write whole-byte values.");
+  static_assert(IsAliasSafe<CharT>::value,
+                "MemoryAccessor can only be used on pointers to char types.");
+
+  using Unsigned = typename LeastWidthInteger<kBits>::Unsigned;
+
+  static inline Unsigned ReadLittleEndianUInt(const CharT* bytes) {
+    return UnalignedAccessor<CharT, kBits>::ReadLittleEndianUInt(bytes);
+  }
+
+  static inline void WriteLittleEndianUInt(CharT* bytes, Unsigned value) {
+    UnalignedAccessor<CharT, kBits>::WriteLittleEndianUInt(bytes, value);
+  }
+
+  static inline Unsigned ReadBigEndianUInt(const CharT* bytes) {
+    return UnalignedAccessor<CharT, kBits>::ReadBigEndianUInt(bytes);
+  }
+
+  static inline void WriteBigEndianUInt(CharT* bytes, Unsigned value) {
+    UnalignedAccessor<CharT, kBits>::WriteBigEndianUInt(bytes, value);
+  }
 };
 
 // Specialization of UIntMemoryAccessor for 16- 32- and 64-bit-aligned reads and

--- a/runtime/cpp/emboss_memory_util.h
+++ b/runtime/cpp/emboss_memory_util.h
@@ -800,6 +800,205 @@ class ContiguousBuffer final {
 using ReadWriteContiguousBuffer = ContiguousBuffer<unsigned char, 1, 0>;
 using ReadOnlyContiguousBuffer = ContiguousBuffer<const unsigned char, 1, 0>;
 
+// IteratorStorage is a view similar to ContiguousBuffer, but instead of
+// wrapping a direct pointer it wraps a generic Iterator, making it compatible
+// with logically-contiguous-but-physically-fragmented backing stores.
+//
+// Because iterators do not guarantee or expose alignment constraints,
+// IteratorStorage simply asserts 1-byte alignment internally and delegates
+// unconditionally to UnalignedAccessor for all memory reads and writes.
+template <typename Iterator>
+class IteratorStorage final {
+ public:
+  using ByteType = typename ::std::remove_reference<
+      decltype(*::std::declval<Iterator>())>::type;
+  using CharT = typename ::std::remove_cv<ByteType>::type;
+
+  template <::std::size_t kSubAlignment = 1, ::std::size_t kSubOffset = 0>
+  using OffsetStorageType = IteratorStorage<Iterator>;
+
+  static_assert(IsAliasSafe<CharT>::value,
+                "IteratorStorage requires a char type iterator.");
+
+  // Constructs a default IteratorStorage with empty, default-constructed
+  // Iterators.
+  template <typename DummyIterator = Iterator,
+            typename = typename ::std::enable_if<
+                ::std::is_default_constructible<DummyIterator>::value>::type>
+  IteratorStorage() : begin_(), end_() {}
+
+  // Constructs from explicit begin and end iterators.
+  IteratorStorage(Iterator begin, Iterator end)
+      : begin_(::std::move(begin)), end_(::std::move(end)) {}
+
+  // Constructs from a container, delegating to the (begin, end) constructor.
+  template <typename Container,
+            typename = typename ::std::enable_if<::std::is_convertible<
+                decltype(::std::begin(::std::declval<Container&>())),
+                Iterator>::value>::type>
+  explicit IteratorStorage(Container&& container)
+      : IteratorStorage(::std::begin(container), ::std::end(container)) {}
+
+  // Allow implicit construction from any compatible IteratorStorage type,
+  // structurally enforcing convertibility via SFINAE.
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value>::type>
+  IteratorStorage(const IteratorStorage<OtherIterator>& other)
+      : begin_(other.begin()), end_(other.end()) {}
+
+  // Assignment from a compatible IteratorStorage.
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value &&
+                !::std::is_same<OtherIterator, Iterator>::value>::type>
+  IteratorStorage& operator=(const IteratorStorage<OtherIterator>& other) {
+    begin_ = other.begin();
+    end_ = other.end();
+    return *this;
+  }
+
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value>::type>
+  bool operator==(const IteratorStorage<OtherIterator>& other) const {
+    return begin_ == other.begin() && end_ == other.end();
+  }
+
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value>::type>
+  bool operator!=(const IteratorStorage<OtherIterator>& other) const {
+    return !(*this == other);
+  }
+
+  // GetOffsetStorage returns a new IteratorStorage that points `offset` bytes
+  // into the current iterator.
+  //
+  // Alignment assertions are intentionally dropped since Iterators may wrap
+  // completely unaligned, scattered chunk pointers. The template parameters
+  // (kSubAlignment, kSubOffset) must be strictly maintained for compatibility
+  // with generated Emboss read/write recursive accessors.
+  template </**/ ::std::size_t kSubAlignment = 1, ::std::size_t kSubOffset = 0>
+  IteratorStorage<Iterator> GetOffsetStorage(::std::size_t offset,
+                                             ::std::size_t size) const {
+    ::std::size_t available = SizeInBytes();
+    ::std::size_t actual_size =
+        offset > available ? 0 : ::std::min(size, available - offset);
+    return IteratorStorage<Iterator>{begin_ + offset,
+                                     begin_ + offset + actual_size};
+  }
+
+  template <typename Dummy = ByteType, typename = typename ::std::enable_if<
+                                           ::std::is_const<Dummy>::value>::type>
+  Iterator cbegin() const {
+    return begin_;
+  }
+
+  template <typename Dummy = ByteType, typename = typename ::std::enable_if<
+                                           ::std::is_const<Dummy>::value>::type>
+  Iterator cend() const {
+    return end_;
+  }
+
+  template </**/ ::std::size_t kBits>
+  typename LeastWidthInteger<kBits>::Unsigned ReadLittleEndianUInt() const {
+    EMBOSS_CHECK_EQ(SizeInBytes() * 8, kBits);
+    return UncheckedReadLittleEndianUInt<kBits>();
+  }
+
+  template </**/ ::std::size_t kBits>
+  typename LeastWidthInteger<kBits>::Unsigned UncheckedReadLittleEndianUInt()
+      const {
+    static_assert(kBits % 8 == 0,
+                  "IteratorStorage::ReadLittleEndianUInt() can only read "
+                  "whole-byte values.");
+    return UnalignedAccessor<CharT, kBits>::ReadLittleEndianUInt(begin_);
+  }
+
+  template </**/ ::std::size_t kBits>
+  typename LeastWidthInteger<kBits>::Unsigned ReadBigEndianUInt() const {
+    EMBOSS_CHECK_EQ(SizeInBytes() * 8, kBits);
+    return UncheckedReadBigEndianUInt<kBits>();
+  }
+
+  template </**/ ::std::size_t kBits>
+  typename LeastWidthInteger<kBits>::Unsigned UncheckedReadBigEndianUInt()
+      const {
+    static_assert(kBits % 8 == 0,
+                  "IteratorStorage::ReadBigEndianUInt() can only read "
+                  "whole-byte values.");
+    return UnalignedAccessor<CharT, kBits>::ReadBigEndianUInt(begin_);
+  }
+
+  template </**/ ::std::size_t kBits>
+  void WriteLittleEndianUInt(
+      typename LeastWidthInteger<kBits>::Unsigned value) const {
+    EMBOSS_CHECK_EQ(SizeInBytes() * 8, kBits);
+    UncheckedWriteLittleEndianUInt<kBits>(value);
+  }
+
+  template </**/ ::std::size_t kBits>
+  void UncheckedWriteLittleEndianUInt(
+      typename LeastWidthInteger<kBits>::Unsigned value) const {
+    static_assert(kBits % 8 == 0,
+                  "IteratorStorage::WriteLittleEndianUInt() can only write "
+                  "whole-byte values.");
+    UnalignedAccessor<CharT, kBits>::WriteLittleEndianUInt(begin_, value);
+  }
+
+  template </**/ ::std::size_t kBits>
+  void WriteBigEndianUInt(
+      typename LeastWidthInteger<kBits>::Unsigned value) const {
+    EMBOSS_CHECK_EQ(SizeInBytes() * 8, kBits);
+    UncheckedWriteBigEndianUInt<kBits>(value);
+  }
+
+  template </**/ ::std::size_t kBits>
+  void UncheckedWriteBigEndianUInt(
+      typename LeastWidthInteger<kBits>::Unsigned value) const {
+    static_assert(kBits % 8 == 0,
+                  "IteratorStorage::WriteBigEndianUInt() can only write "
+                  "whole-byte values.");
+    UnalignedAccessor<CharT, kBits>::WriteBigEndianUInt(begin_, value);
+  }
+
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value>::type>
+  void UncheckedCopyFrom(const IteratorStorage<OtherIterator>& other,
+                         ::std::size_t length) const {
+    ::std::copy_n(other.begin(), length, begin_);
+  }
+
+  template <typename OtherIterator,
+            typename = typename ::std::enable_if<
+                ::std::is_convertible<OtherIterator, Iterator>::value>::type>
+  void CopyFrom(const IteratorStorage<OtherIterator>& other,
+                ::std::size_t length) const {
+    EMBOSS_CHECK_LE(length, SizeInBytes());
+    EMBOSS_CHECK_LE(length, other.SizeInBytes());
+    UncheckedCopyFrom(other, length);
+  }
+
+  bool Ok() const { return true; }
+  ::std::size_t SizeInBytes() const {
+    return static_cast<::std::size_t>(end_ - begin_);
+  }
+  Iterator begin() const { return begin_; }
+  Iterator end() const { return end_; }
+
+ private:
+  Iterator begin_;
+  Iterator end_;
+};
+
+#if __cplusplus >= 201703L
+template <typename Container>
+IteratorStorage(Container&&)
+    -> IteratorStorage<decltype(::std::begin(::std::declval<Container&>()))>;
+#endif
+
 // LittleEndianByteOrderer is a pass-through adapter for a byte buffer class.
 // It is used to implement little-endian bit blocks.
 //

--- a/runtime/cpp/test/BUILD
+++ b/runtime/cpp/test/BUILD
@@ -137,6 +137,7 @@ emboss_cc_util_test(
     copts = ["-DEMBOSS_FORCE_ALL_CHECKS"],
     deps = [
         "//runtime/cpp:cpp_utils",
+        "//runtime/cpp/test/util:noncontiguous_container",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -25,6 +25,7 @@
 #include "gtest/gtest.h"
 #include "runtime/cpp/emboss_memory_util.h"
 #include "runtime/cpp/emboss_prelude.h"
+#include "runtime/cpp/test/util/noncontiguous_container.h"
 
 namespace emboss {
 namespace support {
@@ -148,6 +149,103 @@ TEST(MemoryAccessor, LittleEndianReads) {
   TestMemoryAccessor<std::byte, 8, 0, 64>();
 #endif
   TestMemoryAccessor<unsigned char, 8, 0, 64>();
+}
+
+template <typename CharT, ::std::size_t kBits>
+void TestIteratorUnalignedAccessor() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  // Test all 2^7 = 128 possible ways to partition an 8 byte buffer into chunks.
+  // A 1 bit in `partition_mask` at bit `i` means a chunk boundary exists
+  // between byte `i` and `i + 1`.
+  for (uint8_t partition_mask = 0; partition_mask < 128; ++partition_mask) {
+    std::vector<std::vector<ByteT>> chunks;
+    std::vector<ByteT> current_chunk;
+
+    for (uint8_t i = 0; i < 8; ++i) {
+      current_chunk.push_back(ByteT(i + 1));
+      if ((partition_mask & (1 << i)) || i == 7) {
+        chunks.push_back(std::move(current_chunk));
+        current_chunk.clear();
+      }
+    }
+
+    NoncontiguousContainer<ByteT> container(chunks);
+    EXPECT_EQ(container.size(), 8U);
+
+    EXPECT_EQ(0x0807060504030201UL & (~0x0UL >> (64 - kBits)),
+              (UnalignedAccessor<CharT, kBits>::ReadLittleEndianUInt(
+                  container.begin())))
+        << "Read LE Failed. Mask = " << static_cast<int>(partition_mask)
+        << "; kBits = " << kBits;
+
+    EXPECT_EQ(
+        0x0102030405060708UL >> (64 - kBits),
+        (UnalignedAccessor<CharT, kBits>::ReadBigEndianUInt(container.begin())))
+        << "Read BE Failed. Mask = " << static_cast<int>(partition_mask)
+        << "; kBits = " << kBits;
+
+    auto write_container_le = container;
+    UnalignedAccessor<CharT, kBits>::WriteLittleEndianUInt(
+        write_container_le.begin(),
+        0x7172737475767778UL & (~0x0UL >> (64 - kBits)));
+
+    auto expected_vector_after_write_le = init_container<std::vector<ByteT>>(
+        0x78, 0x77, 0x76, 0x75, 0x74, 0x73, 0x72, 0x71);
+    for (typename std::vector<ByteT>::size_type i = kBits / 8; i < 8; ++i) {
+      expected_vector_after_write_le[i] = ByteT(i + 1);
+    }
+
+    std::vector<ByteT> actual_vector_le;
+    for (auto it = write_container_le.begin(); it != write_container_le.end();
+         ++it) {
+      actual_vector_le.push_back(*it);
+    }
+    EXPECT_EQ(expected_vector_after_write_le, actual_vector_le)
+        << "Write LE Failed. Mask = " << static_cast<int>(partition_mask)
+        << "; kBits = " << kBits;
+
+    auto write_container_be = container;
+    UnalignedAccessor<CharT, kBits>::WriteBigEndianUInt(
+        write_container_be.begin(), 0x7172737475767778UL >> (64 - kBits));
+
+    auto expected_vector_after_write_be = init_container<std::vector<ByteT>>(
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78);
+    for (typename std::vector<ByteT>::size_type i = kBits / 8; i < 8; ++i) {
+      expected_vector_after_write_be[i] = ByteT(i + 1);
+    }
+
+    std::vector<ByteT> actual_vector_be;
+    for (auto it = write_container_be.begin(); it != write_container_be.end();
+         ++it) {
+      actual_vector_be.push_back(*it);
+    }
+    EXPECT_EQ(expected_vector_after_write_be, actual_vector_be)
+        << "Write BE Failed. Mask = " << static_cast<int>(partition_mask)
+        << "; kBits = " << kBits;
+  }
+
+  // Recursively iterate the template:
+  TestIteratorUnalignedAccessor<CharT, kBits - 8>();
+}
+
+template <>
+void TestIteratorUnalignedAccessor<char, 0>() {}
+
+#if __cplusplus >= 201703L
+template <>
+void TestIteratorUnalignedAccessor<std::byte, 0>() {}
+#endif
+
+template <>
+void TestIteratorUnalignedAccessor<unsigned char, 0>() {}
+
+TEST(UnalignedAccessor, IteratorReadsAndWrites) {
+  TestIteratorUnalignedAccessor<char, 64>();
+#if __cplusplus >= 201703L
+  TestIteratorUnalignedAccessor<std::byte, 64>();
+#endif
+  TestIteratorUnalignedAccessor<unsigned char, 64>();
 }
 
 TEST(ContiguousBuffer, OffsetStorageType) {

--- a/runtime/cpp/test/emboss_memory_util_test.cc
+++ b/runtime/cpp/test/emboss_memory_util_test.cc
@@ -248,6 +248,177 @@ TEST(UnalignedAccessor, IteratorReadsAndWrites) {
   TestIteratorUnalignedAccessor<unsigned char, 64>();
 }
 
+template <typename CharT>
+void TestIteratorStorage() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x11), ByteT(0x22)},
+      {ByteT(0x33), ByteT(0x44), ByteT(0x55)},
+      {ByteT(0x66), ByteT(0x77), ByteT(0x88)}};
+
+  NoncontiguousContainer<ByteT> container(chunks);
+
+  IteratorStorage<typename NoncontiguousContainer<ByteT>::iterator> storage(
+      container.begin(), container.end());
+
+  EXPECT_EQ(storage.SizeInBytes(), 8U);
+
+  // Test full 64-bit Reads via UnalignedAccessor delegation
+  EXPECT_EQ(0x8877665544332211UL, storage.template ReadLittleEndianUInt<64>());
+  EXPECT_EQ(0x1122334455667788UL, storage.template ReadBigEndianUInt<64>());
+
+  // Test sub-storage offsets
+  auto substorage1 = storage.template GetOffsetStorage<1, 0>(2, 4);
+  EXPECT_EQ(substorage1.SizeInBytes(), 4U);
+  EXPECT_EQ(0x66554433UL, substorage1.template ReadLittleEndianUInt<32>());
+
+  auto substorage2 = storage.template GetOffsetStorage<1, 0>(
+      6, 4);  // Out of bounds truncates size
+  EXPECT_EQ(substorage2.SizeInBytes(), 2U);
+  EXPECT_EQ(0x8877UL, substorage2.template ReadLittleEndianUInt<16>());
+
+  // Test 32-bit Writes
+  auto write_storage = storage.template GetOffsetStorage<1, 0>(0, 4);
+  write_storage.template WriteLittleEndianUInt<32>(0x99AABBCCUL);
+
+  std::vector<ByteT> verify_le;
+  for (auto it = write_storage.begin(); it != write_storage.end(); ++it) {
+    verify_le.push_back(*it);
+  }
+  std::vector<ByteT> expected_le = {ByteT(0xCC), ByteT(0xBB), ByteT(0xAA),
+                                    ByteT(0x99)};
+  EXPECT_EQ(verify_le, expected_le);
+
+  write_storage.template WriteBigEndianUInt<32>(0x99AABBCCUL);
+  std::vector<ByteT> verify_be;
+  for (auto it = write_storage.begin(); it != write_storage.end(); ++it) {
+    verify_be.push_back(*it);
+  }
+  std::vector<ByteT> expected_be = {ByteT(0x99), ByteT(0xAA), ByteT(0xBB),
+                                    ByteT(0xCC)};
+  EXPECT_EQ(verify_be, expected_be);
+
+  // Test copy from
+  IteratorStorage<typename NoncontiguousContainer<ByteT>::iterator> copy_dest =
+      storage.template GetOffsetStorage<1, 0>(0, 4);
+  copy_dest.CopyFrom(write_storage, 4);
+  std::vector<ByteT> verify_copy;
+  for (auto it = copy_dest.begin(); it != copy_dest.end(); ++it) {
+    verify_copy.push_back(*it);
+  }
+  EXPECT_EQ(verify_copy, expected_be);
+}
+
+template <typename CharT>
+void TestIteratorBitBlock() {
+  using ByteT = typename std::remove_const<CharT>::type;
+
+  std::vector<std::vector<ByteT>> chunks = {
+      {ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00)},
+      {ByteT(0x00), ByteT(0x00), ByteT(0x00)}};
+  NoncontiguousContainer<ByteT> container(chunks);
+
+  IteratorStorage<typename NoncontiguousContainer<ByteT>::iterator> storage(
+      container.begin(), container.end());
+
+  LittleEndianByteOrderer<
+      IteratorStorage<typename NoncontiguousContainer<ByteT>::iterator>>
+      le_orderer(storage);
+  BitBlock<decltype(le_orderer), 64> le_block(le_orderer);
+
+  EXPECT_TRUE(le_block.Ok());
+  EXPECT_EQ(le_block.SizeInBits(), 64U);
+
+  le_block.WriteUInt(0xAABBCCDDEEFF1122UL);
+  EXPECT_EQ(0xAABBCCDDEEFF1122UL, le_block.ReadUInt());
+
+  std::vector<ByteT> expect_le = {ByteT(0x22), ByteT(0x11), ByteT(0xFF),
+                                  ByteT(0xEE), ByteT(0xDD), ByteT(0xCC),
+                                  ByteT(0xBB), ByteT(0xAA)};
+  std::vector<ByteT> verify_le;
+  for (auto it = storage.begin(); it != storage.end(); ++it) {
+    verify_le.push_back(*it);
+  }
+  EXPECT_EQ(expect_le, verify_le);
+
+  BigEndianByteOrderer<
+      IteratorStorage<typename NoncontiguousContainer<ByteT>::iterator>>
+      be_orderer(storage);
+  BitBlock<decltype(be_orderer), 64> be_block(be_orderer);
+
+  be_block.WriteUInt(0x1122334455667788UL);
+  EXPECT_EQ(0x1122334455667788UL, be_block.ReadUInt());
+
+  std::vector<ByteT> expect_be = {ByteT(0x11), ByteT(0x22), ByteT(0x33),
+                                  ByteT(0x44), ByteT(0x55), ByteT(0x66),
+                                  ByteT(0x77), ByteT(0x88)};
+  std::vector<ByteT> verify_be;
+  for (auto it = storage.begin(); it != storage.end(); ++it) {
+    verify_be.push_back(*it);
+  }
+  EXPECT_EQ(expect_be, verify_be);
+
+  // Test Sub-Offsets
+  auto le_subblock = le_block.template GetOffsetStorage<1, 0>(16, 32);
+  EXPECT_EQ(le_subblock.SizeInBits(), 32U);
+  EXPECT_EQ(0x66554433UL, le_subblock.ReadUInt());
+
+  auto be_subblock = be_block.template GetOffsetStorage<1, 0>(16, 32);
+  EXPECT_EQ(be_subblock.SizeInBits(), 32U);
+  EXPECT_EQ(0x33445566UL, be_subblock.ReadUInt());
+}
+
+template <typename CharT>
+void TestCbeginCend() {
+  using ByteT = typename std::remove_const<CharT>::type;
+  std::vector<std::vector<ByteT>> chunks = {{ByteT(0x77)}};
+  ::emboss::support::test::NoncontiguousContainer<ByteT> container(chunks);
+
+  ::emboss::support::IteratorStorage<decltype(container.cbegin())> storage(
+      container.cbegin(), container.cend());
+
+  // Confirm cbegin/cend are exposed and evaluatable for const character
+  // iterators:
+  auto cb = storage.cbegin();
+  auto ce = storage.cend();
+  EXPECT_TRUE(cb != ce);
+}
+
+TEST(IteratorStorage, CbeginCend) {
+  TestCbeginCend<char>();
+  TestCbeginCend<const char>();
+  TestCbeginCend<unsigned char>();
+  TestCbeginCend<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestCbeginCend<std::byte>();
+  TestCbeginCend<const std::byte>();
+#endif
+}
+
+TEST(IteratorStorage, ReadWriteOffsetting) {
+  TestIteratorStorage<char>();
+  TestIteratorStorage<const char>();
+  TestIteratorStorage<unsigned char>();
+  TestIteratorStorage<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestIteratorStorage<std::byte>();
+  TestIteratorStorage<const std::byte>();
+#endif
+}
+
+TEST(BitBlock, IteratorStorageIntegration) {
+  TestIteratorBitBlock<char>();
+  TestIteratorBitBlock<const char>();
+  TestIteratorBitBlock<unsigned char>();
+  TestIteratorBitBlock<const unsigned char>();
+#if __cplusplus >= 201703L
+  TestIteratorBitBlock<std::byte>();
+  TestIteratorBitBlock<const std::byte>();
+#endif
+}
+
 TEST(ContiguousBuffer, OffsetStorageType) {
   EXPECT_TRUE((::std::is_same<
                ContiguousBuffer<char, 2, 0>,

--- a/runtime/cpp/test/util/BUILD
+++ b/runtime/cpp/test/util/BUILD
@@ -1,0 +1,18 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//runtime/cpp/test:build_defs.bzl", "emboss_cc_util_test")
+
+cc_library(
+    name = "noncontiguous_container",
+    hdrs = ["noncontiguous_container.h"],
+    visibility = ["//runtime/cpp/test:__pkg__", "//visibility:public"],
+)
+
+emboss_cc_util_test(
+    name = "noncontiguous_container_test",
+    srcs = ["noncontiguous_container_test.cc"],
+    deps = [
+        ":noncontiguous_container",
+        "//runtime/cpp:cpp_utils",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/runtime/cpp/test/util/noncontiguous_container.h
+++ b/runtime/cpp/test/util/noncontiguous_container.h
@@ -1,0 +1,275 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EMBOSS_RUNTIME_CPP_TEST_UTIL_NONCONTIGUOUS_CONTAINER_H_
+#define EMBOSS_RUNTIME_CPP_TEST_UTIL_NONCONTIGUOUS_CONTAINER_H_
+
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace emboss {
+namespace support {
+namespace test {
+
+// A mock non-contiguous container representing data fragmented across a storage
+// collection of individual chunks.
+template <typename T,
+          template <typename, typename...> class ChunkT = std::vector,
+          template <typename, typename...> class StorageT = std::vector>
+class NoncontiguousContainer {
+ public:
+  using value_type = T;
+  using Chunk = ChunkT<T>;
+  using Storage = StorageT<Chunk>;
+  using size_type = std::size_t;
+
+  template <bool IsConst>
+  class IteratorBase {
+   public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = typename std::conditional<IsConst, const T*, T*>::type;
+    using reference = typename std::conditional<IsConst, const T&, T&>::type;
+
+   private:
+    using StoragePtr =
+        typename std::conditional<IsConst, const Storage*, Storage*>::type;
+    using ChunkIterator =
+        typename std::conditional<IsConst, typename Storage::const_iterator,
+                                  typename Storage::iterator>::type;
+
+    IteratorBase(StoragePtr storage, size_type chunk_idx,
+                 difference_type byte_idx, ChunkIterator chunk_it)
+        : storage_(storage),
+          chunk_idx_(chunk_idx),
+          byte_idx_(byte_idx),
+          chunk_it_(chunk_it) {
+      Normalize();
+    }
+
+    friend IteratorBase<!IsConst>;
+    friend NoncontiguousContainer;
+
+   public:
+    IteratorBase() = default;
+
+    // Allow implicit conversion from non-const to const iterator
+    template <bool WasConst = IsConst,
+              typename = typename std::enable_if<!WasConst>::type>
+    operator IteratorBase<true>() const {
+      return IteratorBase<true>(storage_, chunk_idx_, byte_idx_, chunk_it_);
+    }
+
+    reference operator*() const {
+      auto element_it = chunk_it_->begin();
+      std::advance(element_it, byte_idx_);
+      return *element_it;
+    }
+
+    pointer operator->() const { return &(*(*this)); }
+
+    reference operator[](difference_type n) const { return *(*this + n); }
+
+    IteratorBase& operator++() {
+      ++byte_idx_;
+      Normalize();
+      return *this;
+    }
+
+    IteratorBase operator++(int) {
+      IteratorBase temp = *this;
+      ++(*this);
+      return temp;
+    }
+
+    IteratorBase& operator--() {
+      --byte_idx_;
+      Normalize();
+      return *this;
+    }
+
+    IteratorBase operator--(int) {
+      IteratorBase temp = *this;
+      --(*this);
+      return temp;
+    }
+
+    IteratorBase& operator+=(difference_type n) {
+      byte_idx_ += n;
+      Normalize();
+      return *this;
+    }
+
+    IteratorBase operator+(difference_type n) const {
+      IteratorBase temp = *this;
+      return temp += n;
+    }
+
+    friend IteratorBase operator+(difference_type n, const IteratorBase& it) {
+      return it + n;
+    }
+
+    IteratorBase& operator-=(difference_type n) {
+      byte_idx_ -= n;
+      Normalize();
+      return *this;
+    }
+
+    IteratorBase operator-(difference_type n) const {
+      IteratorBase temp = *this;
+      return temp -= n;
+    }
+
+    template <bool OtherConst>
+    difference_type operator-(const IteratorBase<OtherConst>& other) const {
+      difference_type dist = 0;
+      IteratorBase temp = other;
+
+      // If other is ahead of us, compute distance and negate
+      if (temp > *this) {
+        return -(temp - *this);
+      }
+
+      while (temp != *this) {
+        size_type temp_remaining = temp.chunk_it_->size() - temp.byte_idx_;
+
+        if (temp.chunk_idx_ == this->chunk_idx_) {
+          dist += (this->byte_idx_ - temp.byte_idx_);
+          break;
+        } else {
+          dist += temp_remaining;
+          ++temp.chunk_idx_;
+          ++temp.chunk_it_;
+          temp.byte_idx_ = 0;
+          temp.Normalize();
+        }
+      }
+      return dist;
+    }
+
+    template <bool OtherConst>
+    bool operator==(const IteratorBase<OtherConst>& other) const {
+      return storage_ == other.storage_ && chunk_idx_ == other.chunk_idx_ &&
+             byte_idx_ == other.byte_idx_;
+    }
+
+    template <bool OtherConst>
+    bool operator!=(const IteratorBase<OtherConst>& other) const {
+      return !(*this == other);
+    }
+
+    template <bool OtherConst>
+    bool operator<(const IteratorBase<OtherConst>& other) const {
+      if (chunk_idx_ != other.chunk_idx_) return chunk_idx_ < other.chunk_idx_;
+      return byte_idx_ < other.byte_idx_;
+    }
+
+    template <bool OtherConst>
+    bool operator>(const IteratorBase<OtherConst>& other) const {
+      return other < *this;
+    }
+
+    template <bool OtherConst>
+    bool operator<=(const IteratorBase<OtherConst>& other) const {
+      return !(other < *this);
+    }
+
+    template <bool OtherConst>
+    bool operator>=(const IteratorBase<OtherConst>& other) const {
+      return !(*this < other);
+    }
+
+   private:
+    StoragePtr storage_ = nullptr;
+    size_type chunk_idx_ = 0;
+    difference_type byte_idx_ = 0;
+    ChunkIterator chunk_it_ = {};
+
+    void Normalize() {
+      if (!storage_) return;
+
+      // Handle backward normalization
+      while (byte_idx_ < 0) {
+        if (chunk_idx_ == 0) {
+          // Invalid `byte_idx_`, but required for random_access_iterator.
+          return;
+        }
+        --chunk_idx_;
+        --chunk_it_;
+        byte_idx_ += static_cast<difference_type>(chunk_it_->size());
+      }
+
+      // Handle forward normalization
+      while (chunk_idx_ < storage_->size() &&
+             byte_idx_ >= static_cast<difference_type>(chunk_it_->size())) {
+        byte_idx_ -= static_cast<difference_type>(chunk_it_->size());
+        ++chunk_idx_;
+        ++chunk_it_;
+      }
+    }
+  };
+
+  using iterator = IteratorBase<false>;
+  using const_iterator = IteratorBase<true>;
+
+  explicit NoncontiguousContainer(Storage chunks) : chunks_(std::move(chunks)) {
+    for (const auto& chunk : chunks_) {
+      total_size_ += chunk.size();
+    }
+  }
+
+  NoncontiguousContainer(
+      std::initializer_list<typename Storage::value_type> init)
+      : chunks_(init) {
+    for (const auto& chunk : chunks_) {
+      total_size_ += chunk.size();
+    }
+  }
+
+  iterator begin() { return iterator(&chunks_, 0, 0, chunks_.begin()); }
+  iterator end() {
+    return iterator(&chunks_, chunks_.size(), 0, chunks_.end());
+  }
+
+  const_iterator begin() const {
+    return const_iterator(&chunks_, 0, 0, chunks_.begin());
+  }
+  const_iterator end() const {
+    return const_iterator(&chunks_, chunks_.size(), 0, chunks_.end());
+  }
+
+  const_iterator cbegin() const {
+    return const_iterator(&chunks_, 0, 0, chunks_.begin());
+  }
+  const_iterator cend() const {
+    return const_iterator(&chunks_, chunks_.size(), 0, chunks_.end());
+  }
+
+  size_type size() const { return total_size_; }
+
+ private:
+  Storage chunks_;
+  size_type total_size_ = 0;
+};
+
+}  // namespace test
+}  // namespace support
+}  // namespace emboss
+
+#endif  // EMBOSS_RUNTIME_CPP_TEST_UTIL_NONCONTIGUOUS_CONTAINER_H_

--- a/runtime/cpp/test/util/noncontiguous_container_test.cc
+++ b/runtime/cpp/test/util/noncontiguous_container_test.cc
@@ -1,0 +1,257 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/cpp/test/util/noncontiguous_container.h"
+
+#include <algorithm>
+#include <list>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace emboss {
+namespace support {
+namespace test {
+namespace {
+
+template <typename Container>
+bool IsNoncontiguous(const Container& container) {
+  if (container.size() <= 1) return false;
+  auto it = container.begin();
+  auto prev = it++;
+  for (; it != container.end(); ++it, ++prev) {
+    if (std::addressof(*it) != std::addressof(*prev) + 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST(NoncontiguousContainer, BasicStringChunkIteration) {
+  NoncontiguousContainer<char, std::basic_string> container(
+      {"12", "", "3", "456"});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  std::string result;
+  for (auto it = container.cbegin(); it != container.cend(); ++it) {
+    result += *it;
+  }
+  EXPECT_EQ("123456", result);
+}
+
+TEST(NoncontiguousContainer, GenericVectorIteration) {
+  NoncontiguousContainer<int> container({{1, 2}, {}, {3}, {4, 5, 6}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  int sum = 0;
+  for (int v : container) {
+    sum += v;
+  }
+  EXPECT_EQ(21, sum);
+}
+
+TEST(NoncontiguousContainer, StdListStorageIteration) {
+  NoncontiguousContainer<int, std::vector, std::list> container(
+      {{10, 20}, {30}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  int sum = 0;
+  for (int v : container) {
+    sum += v;
+  }
+  EXPECT_EQ(60, sum);
+}
+
+TEST(NoncontiguousContainer, RandomAccessAdvance) {
+  NoncontiguousContainer<char> container({{'1', '2'}, {'3'}, {'4', '5', '6'}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  auto it = container.begin();
+  EXPECT_EQ('1', *it);
+
+  it += 2;
+  EXPECT_EQ('3', *it);
+
+  it += 3;
+  EXPECT_EQ('6', *it);
+
+  it -= 4;
+  EXPECT_EQ('2', *it);
+}
+
+TEST(NoncontiguousContainer, DistanceOperator) {
+  NoncontiguousContainer<char> container(
+      {{'a', 'b', 'c'}, {'d', 'e', 'f'}, {'g', 'h', 'i'}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  auto begin = container.begin();
+  auto end = container.end();
+
+  EXPECT_EQ(9, end - begin);
+  EXPECT_EQ(-9, begin - end);
+
+  auto mid = begin + 4;
+  EXPECT_EQ('e', *mid);
+  EXPECT_EQ(4, mid - begin);
+  EXPECT_EQ(-4, begin - mid);
+  EXPECT_EQ(5, end - mid);
+  EXPECT_EQ(-5, mid - end);
+}
+
+TEST(NoncontiguousContainer, RelationalOperators) {
+  NoncontiguousContainer<int> container({{1, 2}, {3, 4}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  auto it1 = container.begin();
+  auto it2 = container.begin() + 1;
+  auto it3 = container.begin() + 2;
+
+  EXPECT_TRUE(it1 == it1);
+  EXPECT_TRUE(it1 != it2);
+
+  EXPECT_TRUE(it1 < it2);
+  EXPECT_TRUE(it2 > it1);
+  EXPECT_TRUE(it1 <= it2);
+  EXPECT_TRUE(it1 <= it1);
+  EXPECT_TRUE(it2 >= it1);
+  EXPECT_TRUE(it2 >= it2);
+
+  EXPECT_TRUE(it1 < it3);
+  EXPECT_TRUE(it2 < it3);
+}
+
+TEST(NoncontiguousContainer, DecrementFromEnd) {
+  NoncontiguousContainer<int> container({{1, 2}, {3}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  auto it = container.end();
+  --it;
+  EXPECT_EQ(3, *it);
+  it -= 2;
+  EXPECT_EQ(1, *it);
+}
+
+TEST(NoncontiguousContainer, ContiguousOrEmpty) {
+  NoncontiguousContainer<int> empty({});
+  EXPECT_EQ(empty.begin(), empty.end());
+  EXPECT_EQ(0U, empty.size());
+
+  NoncontiguousContainer<int> single({{42}});
+  EXPECT_FALSE(IsNoncontiguous(single));
+  EXPECT_EQ(1U, single.size());
+  EXPECT_EQ(42, *single.begin());
+
+  auto it = single.begin();
+  ++it;
+  EXPECT_EQ(it, single.end());
+
+  NoncontiguousContainer<int> contiguous({{1, 2, 3, 4, 5}});
+  EXPECT_FALSE(IsNoncontiguous(contiguous));
+  EXPECT_EQ(5U, contiguous.size());
+
+  int sum = 0;
+  for (int v : contiguous) {
+    sum += v;
+  }
+  EXPECT_EQ(15, sum);
+}
+
+TEST(NoncontiguousContainer, StdCopyAcrossChunks) {
+  NoncontiguousContainer<char> container({{'a', 'b'}, {'c', 'd'}, {'e', 'f'}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  {
+    std::string dest = "    ";
+    auto start = container.begin() + 1;
+    auto dest_it = dest.begin();
+    for (int i = 0; i < 4; ++i) {
+      *dest_it++ = *start++;
+    }
+    EXPECT_EQ("bcde", dest);
+  }
+
+  {
+    std::string dest;
+    dest.resize(3);
+    std::copy_n(container.begin(), 3, dest.begin());
+    EXPECT_EQ("abc", dest);
+  }
+
+  {
+    std::string dest;
+    std::copy(container.begin() + 2, container.end(), std::back_inserter(dest));
+    EXPECT_EQ("cdef", dest);
+  }
+
+  {
+    std::string dest;
+    std::copy(container.begin(), container.end(), std::back_inserter(dest));
+    EXPECT_EQ("abcdef", dest);
+  }
+
+  {
+    std::string src = "123456";
+    std::copy(src.begin(), src.end(), container.begin());
+
+    std::string dest;
+    std::copy(container.begin(), container.end(), std::back_inserter(dest));
+    EXPECT_EQ(src, dest);
+  }
+}
+
+TEST(NoncontiguousContainer, ConsecutiveEmptyChunks) {
+  NoncontiguousContainer<char> container({{'a'}, {}, {}, {'b'}, {}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  auto begin = container.begin();
+  auto end = container.end();
+
+  EXPECT_EQ(2, end - begin);
+  EXPECT_EQ('a', *begin);
+
+  auto second = begin + 1;
+  EXPECT_EQ('b', *second);
+
+  auto after_second = second + 1;
+  EXPECT_TRUE(after_second == end);
+}
+
+TEST(NoncontiguousContainer, IteratorTraitsAndConstValidation) {
+  using ContainerT = NoncontiguousContainer<int>;
+
+  using CatT = typename ContainerT::iterator::iterator_category;
+  using IsRandomCat = std::is_same<CatT, std::random_access_iterator_tag>;
+  EXPECT_TRUE(IsRandomCat::value);
+
+  using ValT = typename ContainerT::iterator::value_type;
+  using IsIntVal = std::is_same<ValT, int>;
+  EXPECT_TRUE(IsIntVal::value);
+
+  const ContainerT container({{1}, {2, 3}});
+  EXPECT_TRUE(IsNoncontiguous(container));
+
+  int sum = 0;
+  for (ContainerT::const_iterator it = container.cbegin();
+       it != container.cend(); ++it) {
+    sum += *it;
+  }
+  EXPECT_EQ(6, sum);
+}
+
+}  // namespace
+}  // namespace test
+}  // namespace support
+}  // namespace emboss

--- a/testdata/golden_cpp/alignments.emb.h
+++ b/testdata/golden_cpp/alignments.emb.h
@@ -1281,6 +1281,40 @@ MakeAlignedAlignmentsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAlignmentsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAlignmentsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAlignmentsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAlignmentsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAlignmentsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAlignmentsView( Container &&emboss_reserved_local_container) {
+  return GenericAlignmentsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace Placeholder4 {
@@ -1697,6 +1731,40 @@ MakeAlignedPlaceholder4View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericPlaceholder4View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakePlaceholder4View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericPlaceholder4View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericPlaceholder4View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericPlaceholder4View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakePlaceholder4View( Container &&emboss_reserved_local_container) {
+  return GenericPlaceholder4View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -2193,6 +2261,40 @@ MakeAlignedPlaceholder6View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericPlaceholder6View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakePlaceholder6View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericPlaceholder6View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericPlaceholder6View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericPlaceholder6View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakePlaceholder6View( Container &&emboss_reserved_local_container) {
+  return GenericPlaceholder6View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Alignments {

--- a/testdata/golden_cpp/anonymous_bits.emb.h
+++ b/testdata/golden_cpp/anonymous_bits.emb.h
@@ -646,6 +646,40 @@ MakeAlignedEmbossReservedAnonymousField2View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField2View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField2View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField2View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 enum class Bar : ::std::uint64_t {
   BAR = static_cast</**/::std::int32_t>(0LL),
   BAZ = static_cast</**/::std::int32_t>(1LL),
@@ -1233,6 +1267,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace Foo
@@ -1893,6 +1961,40 @@ MakeAlignedFooView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericFooView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeFooView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericFooView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericFooView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericFooView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeFooView( Container &&emboss_reserved_local_container) {
+  return GenericFooView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Foo {

--- a/testdata/golden_cpp/auto_array_size.emb.h
+++ b/testdata/golden_cpp/auto_array_size.emb.h
@@ -541,6 +541,40 @@ MakeAlignedElementView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericElementView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeElementView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericElementView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericElementView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericElementView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeElementView( Container &&emboss_reserved_local_container) {
+  return GenericElementView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1330,6 +1364,40 @@ MakeAlignedAutoSizeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAutoSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAutoSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAutoSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAutoSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAutoSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAutoSizeView( Container &&emboss_reserved_local_container) {
+  return GenericAutoSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Element {

--- a/testdata/golden_cpp/bcd.emb.h
+++ b/testdata/golden_cpp/bcd.emb.h
@@ -729,6 +729,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace BcdSizes
 
 
@@ -1947,6 +1981,40 @@ MakeAlignedBcdSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBcdSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBcdSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBcdSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBcdSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBcdSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBcdSizesView( Container &&emboss_reserved_local_container) {
+  return GenericBcdSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace BcdBigEndian {
@@ -2363,6 +2431,40 @@ MakeAlignedBcdBigEndianView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBcdBigEndianView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBcdBigEndianView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBcdBigEndianView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBcdBigEndianView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBcdBigEndianView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBcdBigEndianView( Container &&emboss_reserved_local_container) {
+  return GenericBcdBigEndianView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace BcdSizes {

--- a/testdata/golden_cpp/bits.emb.h
+++ b/testdata/golden_cpp/bits.emb.h
@@ -827,6 +827,40 @@ MakeAlignedOneByteView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOneByteView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOneByteView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOneByteView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOneByteView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOneByteView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOneByteView( Container &&emboss_reserved_local_container) {
+  return GenericOneByteView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace FourByte {
@@ -1428,6 +1462,40 @@ MakeAlignedTwoByteWithGapsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericTwoByteWithGapsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeTwoByteWithGapsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericTwoByteWithGapsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericTwoByteWithGapsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericTwoByteWithGapsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeTwoByteWithGapsView( Container &&emboss_reserved_local_container) {
+  return GenericTwoByteWithGapsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace FourByte
@@ -2216,6 +2284,40 @@ MakeAlignedFourByteView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericFourByteView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeFourByteView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericFourByteView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericFourByteView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericFourByteView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeFourByteView( Container &&emboss_reserved_local_container) {
+  return GenericFourByteView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2720,6 +2822,40 @@ MakeAlignedArrayInBitsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericArrayInBitsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeArrayInBitsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericArrayInBitsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericArrayInBitsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericArrayInBitsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeArrayInBitsView( Container &&emboss_reserved_local_container) {
+  return GenericArrayInBitsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace ArrayInBitsInStruct {
@@ -3134,6 +3270,40 @@ MakeAlignedArrayInBitsInStructView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericArrayInBitsInStructView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeArrayInBitsInStructView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericArrayInBitsInStructView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericArrayInBitsInStructView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericArrayInBitsInStructView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeArrayInBitsInStructView( Container &&emboss_reserved_local_container) {
+  return GenericArrayInBitsInStructView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -3824,6 +3994,40 @@ MakeAlignedStructOfBitsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructOfBitsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructOfBitsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructOfBitsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructOfBitsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructOfBitsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructOfBitsView( Container &&emboss_reserved_local_container) {
+  return GenericStructOfBitsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace BitArray {
@@ -4242,6 +4446,40 @@ MakeAlignedBitArrayView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBitArrayView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBitArrayView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBitArrayView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBitArrayView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBitArrayView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBitArrayView( Container &&emboss_reserved_local_container) {
+  return GenericBitArrayView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace OneByte {

--- a/testdata/golden_cpp/complex_offset.emb.h
+++ b/testdata/golden_cpp/complex_offset.emb.h
@@ -467,6 +467,40 @@ MakeAlignedLengthView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericLengthView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeLengthView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericLengthView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericLengthView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericLengthView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeLengthView( Container &&emboss_reserved_local_container) {
+  return GenericLengthView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -997,6 +1031,40 @@ MakeAlignedDataView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericDataView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeDataView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericDataView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericDataView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericDataView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeDataView( Container &&emboss_reserved_local_container) {
+  return GenericDataView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -2816,6 +2884,40 @@ MakeAlignedPackedFieldsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericPackedFieldsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakePackedFieldsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericPackedFieldsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericPackedFieldsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericPackedFieldsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakePackedFieldsView( Container &&emboss_reserved_local_container) {
+  return GenericPackedFieldsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Length {

--- a/testdata/golden_cpp/complex_structure.emb.h
+++ b/testdata/golden_cpp/complex_structure.emb.h
@@ -638,6 +638,40 @@ MakeAlignedRegisterLayoutView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRegisterLayoutView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRegisterLayoutView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRegisterLayoutView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRegisterLayoutView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRegisterLayoutView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRegisterLayoutView( Container &&emboss_reserved_local_container) {
+  return GenericRegisterLayoutView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace ArrayElement {
@@ -1052,6 +1086,40 @@ MakeAlignedArrayElementView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericArrayElementView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeArrayElementView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericArrayElementView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericArrayElementView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericArrayElementView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeArrayElementView( Container &&emboss_reserved_local_container) {
+  return GenericArrayElementView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -1736,6 +1804,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace Complex
@@ -3340,6 +3442,40 @@ MakeAlignedComplexView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericComplexView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeComplexView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericComplexView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericComplexView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericComplexView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeComplexView( Container &&emboss_reserved_local_container) {
+  return GenericComplexView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace RegisterLayout {

--- a/testdata/golden_cpp/condition.emb.h
+++ b/testdata/golden_cpp/condition.emb.h
@@ -832,6 +832,40 @@ MakeAlignedBasicConditionalView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBasicConditionalView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBasicConditionalView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBasicConditionalView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBasicConditionalView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBasicConditionalView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBasicConditionalView( Container &&emboss_reserved_local_container) {
+  return GenericBasicConditionalView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1360,6 +1394,40 @@ MakeAlignedNegativeConditionalView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNegativeConditionalView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNegativeConditionalView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNegativeConditionalView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNegativeConditionalView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNegativeConditionalView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNegativeConditionalView( Container &&emboss_reserved_local_container) {
+  return GenericNegativeConditionalView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -1944,6 +2012,40 @@ MakeAlignedConditionalAndUnconditionalOverlappingFinalFieldView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalAndUnconditionalOverlappingFinalFieldView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalAndUnconditionalOverlappingFinalFieldView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalAndUnconditionalOverlappingFinalFieldView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalAndUnconditionalOverlappingFinalFieldView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalAndUnconditionalOverlappingFinalFieldView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalAndUnconditionalOverlappingFinalFieldView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalAndUnconditionalOverlappingFinalFieldView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2442,6 +2544,40 @@ MakeAlignedConditionalBasicConditionalFieldFirstView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalBasicConditionalFieldFirstView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalBasicConditionalFieldFirstView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalBasicConditionalFieldFirstView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalBasicConditionalFieldFirstView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalBasicConditionalFieldFirstView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalBasicConditionalFieldFirstView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalBasicConditionalFieldFirstView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -3059,6 +3195,40 @@ MakeAlignedConditionalAndDynamicLocationView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalAndDynamicLocationView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalAndDynamicLocationView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalAndDynamicLocationView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalAndDynamicLocationView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalAndDynamicLocationView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalAndDynamicLocationView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalAndDynamicLocationView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -3588,6 +3758,40 @@ MakeAlignedConditionUsesMinIntView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionUsesMinIntView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionUsesMinIntView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionUsesMinIntView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionUsesMinIntView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionUsesMinIntView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionUsesMinIntView( Container &&emboss_reserved_local_container) {
+  return GenericConditionUsesMinIntView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4204,6 +4408,40 @@ MakeAlignedNestedConditionalView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNestedConditionalView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNestedConditionalView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNestedConditionalView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNestedConditionalView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNestedConditionalView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNestedConditionalView( Container &&emboss_reserved_local_container) {
+  return GenericNestedConditionalView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4823,6 +5061,40 @@ MakeAlignedCorrectNestedConditionalView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericCorrectNestedConditionalView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeCorrectNestedConditionalView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericCorrectNestedConditionalView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericCorrectNestedConditionalView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericCorrectNestedConditionalView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeCorrectNestedConditionalView( Container &&emboss_reserved_local_container) {
+  return GenericCorrectNestedConditionalView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -5323,6 +5595,40 @@ MakeAlignedAlwaysFalseConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAlwaysFalseConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAlwaysFalseConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAlwaysFalseConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAlwaysFalseConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAlwaysFalseConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAlwaysFalseConditionView( Container &&emboss_reserved_local_container) {
+  return GenericAlwaysFalseConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace OnlyAlwaysFalseCondition {
@@ -5741,6 +6047,40 @@ MakeAlignedOnlyAlwaysFalseConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOnlyAlwaysFalseConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOnlyAlwaysFalseConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOnlyAlwaysFalseConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOnlyAlwaysFalseConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOnlyAlwaysFalseConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOnlyAlwaysFalseConditionView( Container &&emboss_reserved_local_container) {
+  return GenericOnlyAlwaysFalseConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 namespace EmptyStruct {
 
@@ -6079,6 +6419,40 @@ MakeAlignedEmptyStructView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmptyStructView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmptyStructView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmptyStructView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmptyStructView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmptyStructView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmptyStructView( Container &&emboss_reserved_local_container) {
+  return GenericEmptyStructView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -6693,6 +7067,40 @@ MakeAlignedAlwaysFalseConditionDynamicSizeView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAlwaysFalseConditionDynamicSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAlwaysFalseConditionDynamicSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAlwaysFalseConditionDynamicSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAlwaysFalseConditionDynamicSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAlwaysFalseConditionDynamicSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAlwaysFalseConditionDynamicSizeView( Container &&emboss_reserved_local_container) {
+  return GenericAlwaysFalseConditionDynamicSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -7273,6 +7681,40 @@ MakeAlignedConditionDoesNotContributeToSizeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionDoesNotContributeToSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionDoesNotContributeToSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionDoesNotContributeToSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionDoesNotContributeToSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionDoesNotContributeToSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionDoesNotContributeToSizeView( Container &&emboss_reserved_local_container) {
+  return GenericConditionDoesNotContributeToSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 enum class OnOff : ::std::uint64_t {
   OFF = static_cast</**/::std::int32_t>(0LL),
@@ -7977,6 +8419,40 @@ MakeAlignedEnumConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEnumConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEnumConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEnumConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEnumConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEnumConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEnumConditionView( Container &&emboss_reserved_local_container) {
+  return GenericEnumConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -8506,6 +8982,40 @@ MakeAlignedNegativeEnumConditionView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNegativeEnumConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNegativeEnumConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNegativeEnumConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNegativeEnumConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNegativeEnumConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNegativeEnumConditionView( Container &&emboss_reserved_local_container) {
+  return GenericNegativeEnumConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -9038,6 +9548,40 @@ MakeAlignedLessThanConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericLessThanConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeLessThanConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericLessThanConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericLessThanConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericLessThanConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeLessThanConditionView( Container &&emboss_reserved_local_container) {
+  return GenericLessThanConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -9566,6 +10110,40 @@ MakeAlignedLessThanOrEqualConditionView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericLessThanOrEqualConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeLessThanOrEqualConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericLessThanOrEqualConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericLessThanOrEqualConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericLessThanOrEqualConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeLessThanOrEqualConditionView( Container &&emboss_reserved_local_container) {
+  return GenericLessThanOrEqualConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -10098,6 +10676,40 @@ MakeAlignedGreaterThanOrEqualConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericGreaterThanOrEqualConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeGreaterThanOrEqualConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericGreaterThanOrEqualConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericGreaterThanOrEqualConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericGreaterThanOrEqualConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeGreaterThanOrEqualConditionView( Container &&emboss_reserved_local_container) {
+  return GenericGreaterThanOrEqualConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -10626,6 +11238,40 @@ MakeAlignedGreaterThanConditionView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericGreaterThanConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeGreaterThanConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericGreaterThanConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericGreaterThanConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericGreaterThanConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeGreaterThanConditionView( Container &&emboss_reserved_local_container) {
+  return GenericGreaterThanConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -11246,6 +11892,40 @@ MakeAlignedRangeConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRangeConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRangeConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRangeConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRangeConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRangeConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRangeConditionView( Container &&emboss_reserved_local_container) {
+  return GenericRangeConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -11864,6 +12544,40 @@ MakeAlignedReverseRangeConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericReverseRangeConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeReverseRangeConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericReverseRangeConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericReverseRangeConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericReverseRangeConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeReverseRangeConditionView( Container &&emboss_reserved_local_container) {
+  return GenericReverseRangeConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -12480,6 +13194,40 @@ MakeAlignedAndConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAndConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAndConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAndConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAndConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAndConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAndConditionView( Container &&emboss_reserved_local_container) {
+  return GenericAndConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -13094,6 +13842,40 @@ MakeAlignedOrConditionView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOrConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOrConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOrConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOrConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOrConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOrConditionView( Container &&emboss_reserved_local_container) {
+  return GenericOrConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -13884,6 +14666,40 @@ MakeAlignedChoiceConditionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericChoiceConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeChoiceConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericChoiceConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericChoiceConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericChoiceConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeChoiceConditionView( Container &&emboss_reserved_local_container) {
+  return GenericChoiceConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -14390,6 +15206,40 @@ MakeAlignedEmbossReservedAnonymousField3View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField3View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField3View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField3View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField3View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField3View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField3View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField3View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace ContainsBits
 
 
@@ -14860,6 +15710,40 @@ MakeAlignedContainsBitsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericContainsBitsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeContainsBitsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericContainsBitsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericContainsBitsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericContainsBitsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeContainsBitsView( Container &&emboss_reserved_local_container) {
+  return GenericContainsBitsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -15388,6 +16272,40 @@ MakeAlignedContainsContainsBitsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericContainsContainsBitsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeContainsContainsBitsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericContainsContainsBitsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericContainsContainsBitsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericContainsContainsBitsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeContainsContainsBitsView( Container &&emboss_reserved_local_container) {
+  return GenericContainsContainsBitsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -15978,6 +16896,40 @@ MakeAlignedType0View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericType0View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeType0View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericType0View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericType0View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericType0View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeType0View( Container &&emboss_reserved_local_container) {
+  return GenericType0View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -16559,6 +17511,40 @@ MakeAlignedType1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericType1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeType1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericType1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericType1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericType1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeType1View( Container &&emboss_reserved_local_container) {
+  return GenericType1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace ConditionalInline
@@ -17165,6 +18151,40 @@ MakeAlignedConditionalInlineView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalInlineView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalInlineView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalInlineView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalInlineView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalInlineView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalInlineView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalInlineView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -17753,6 +18773,40 @@ MakeAlignedEmbossReservedAnonymousField2View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField2View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField2View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField2View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace ConditionalAnonymous
@@ -18387,6 +19441,40 @@ MakeAlignedConditionalAnonymousView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalAnonymousView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalAnonymousView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalAnonymousView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalAnonymousView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalAnonymousView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalAnonymousView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalAnonymousView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -18809,6 +19897,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace ConditionalOnFlag
@@ -19342,6 +20464,40 @@ MakeAlignedConditionalOnFlagView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConditionalOnFlagView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConditionalOnFlagView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConditionalOnFlagView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConditionalOnFlagView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConditionalOnFlagView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConditionalOnFlagView( Container &&emboss_reserved_local_container) {
+  return GenericConditionalOnFlagView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace BasicConditional {

--- a/testdata/golden_cpp/dynamic_size.emb.h
+++ b/testdata/golden_cpp/dynamic_size.emb.h
@@ -904,6 +904,40 @@ MakeAlignedMessageView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericMessageView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeMessageView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericMessageView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericMessageView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericMessageView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeMessageView( Container &&emboss_reserved_local_container) {
+  return GenericMessageView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1445,6 +1479,40 @@ MakeAlignedImageView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericImageView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeImageView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericImageView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericImageView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericImageView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeImageView( Container &&emboss_reserved_local_container) {
+  return GenericImageView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -2322,6 +2390,40 @@ MakeAlignedTwoRegionsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericTwoRegionsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeTwoRegionsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericTwoRegionsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericTwoRegionsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericTwoRegionsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeTwoRegionsView( Container &&emboss_reserved_local_container) {
+  return GenericTwoRegionsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2939,6 +3041,40 @@ MakeAlignedMultipliedSizeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericMultipliedSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeMultipliedSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericMultipliedSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericMultipliedSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericMultipliedSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeMultipliedSizeView( Container &&emboss_reserved_local_container) {
+  return GenericMultipliedSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4096,6 +4232,40 @@ MakeAlignedNegativeTermsInSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNegativeTermsInSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNegativeTermsInSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNegativeTermsInSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNegativeTermsInSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNegativeTermsInSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNegativeTermsInSizesView( Container &&emboss_reserved_local_container) {
+  return GenericNegativeTermsInSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -4625,6 +4795,40 @@ MakeAlignedNegativeTermInLocationView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNegativeTermInLocationView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNegativeTermInLocationView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNegativeTermInLocationView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNegativeTermInLocationView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNegativeTermInLocationView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNegativeTermInLocationView( Container &&emboss_reserved_local_container) {
+  return GenericNegativeTermInLocationView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -5329,6 +5533,40 @@ MakeAlignedChainedSizeView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericChainedSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeChainedSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericChainedSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericChainedSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericChainedSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeChainedSizeView( Container &&emboss_reserved_local_container) {
+  return GenericChainedSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -5909,6 +6147,40 @@ MakeAlignedFinalFieldOverlapsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericFinalFieldOverlapsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeFinalFieldOverlapsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericFinalFieldOverlapsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericFinalFieldOverlapsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericFinalFieldOverlapsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeFinalFieldOverlapsView( Container &&emboss_reserved_local_container) {
+  return GenericFinalFieldOverlapsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -6608,6 +6880,40 @@ MakeAlignedDynamicFinalFieldOverlapsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericDynamicFinalFieldOverlapsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeDynamicFinalFieldOverlapsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericDynamicFinalFieldOverlapsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericDynamicFinalFieldOverlapsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericDynamicFinalFieldOverlapsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeDynamicFinalFieldOverlapsView( Container &&emboss_reserved_local_container) {
+  return GenericDynamicFinalFieldOverlapsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -7137,6 +7443,40 @@ MakeAlignedDynamicFieldDependsOnLaterFieldView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericDynamicFieldDependsOnLaterFieldView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeDynamicFieldDependsOnLaterFieldView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericDynamicFieldDependsOnLaterFieldView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericDynamicFieldDependsOnLaterFieldView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericDynamicFieldDependsOnLaterFieldView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeDynamicFieldDependsOnLaterFieldView( Container &&emboss_reserved_local_container) {
+  return GenericDynamicFieldDependsOnLaterFieldView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -7719,6 +8059,40 @@ MakeAlignedDynamicFieldDoesNotAffectSizeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericDynamicFieldDoesNotAffectSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeDynamicFieldDoesNotAffectSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericDynamicFieldDoesNotAffectSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericDynamicFieldDoesNotAffectSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericDynamicFieldDoesNotAffectSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeDynamicFieldDoesNotAffectSizeView( Container &&emboss_reserved_local_container) {
+  return GenericDynamicFieldDoesNotAffectSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Message {

--- a/testdata/golden_cpp/enum.emb.h
+++ b/testdata/golden_cpp/enum.emb.h
@@ -537,6 +537,40 @@ MakeAlignedConstantsView(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
 }
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConstantsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConstantsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConstantsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConstantsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConstantsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConstantsView( Container &&emboss_reserved_local_container) {
+  return GenericConstantsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
 enum class Kind : ::std::uint64_t {
   WIDGET = static_cast</**/::std::int32_t>(0LL),
   SPROCKET = static_cast</**/::std::int32_t>(1LL),
@@ -1908,6 +1942,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace ManifestEntry
 
 
@@ -2576,6 +2644,40 @@ MakeAlignedManifestEntryView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericManifestEntryView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeManifestEntryView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericManifestEntryView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericManifestEntryView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericManifestEntryView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeManifestEntryView( Container &&emboss_reserved_local_container) {
+  return GenericManifestEntryView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace StructContainingEnum {
@@ -3079,6 +3181,40 @@ MakeAlignedStructContainingEnumView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructContainingEnumView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructContainingEnumView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructContainingEnumView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructContainingEnumView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructContainingEnumView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructContainingEnumView( Container &&emboss_reserved_local_container) {
+  return GenericStructContainingEnumView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Constants {

--- a/testdata/golden_cpp/enum_case.emb.h
+++ b/testdata/golden_cpp/enum_case.emb.h
@@ -840,6 +840,40 @@ MakeAlignedUseKCamelEnumCaseView(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
 }
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericUseKCamelEnumCaseView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeUseKCamelEnumCaseView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericUseKCamelEnumCaseView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericUseKCamelEnumCaseView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericUseKCamelEnumCaseView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeUseKCamelEnumCaseView( Container &&emboss_reserved_local_container) {
+  return GenericUseKCamelEnumCaseView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
 enum class EnumShoutyAndKCamel : ::std::uint64_t {
   FIRST = static_cast</**/::std::int32_t>(0LL),
   kFirst = static_cast</**/::std::int32_t>(0LL),

--- a/testdata/golden_cpp/explicit_sizes.emb.h
+++ b/testdata/golden_cpp/explicit_sizes.emb.h
@@ -653,6 +653,40 @@ MakeAlignedSizedUIntArraysView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizedUIntArraysView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizedUIntArraysView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizedUIntArraysView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizedUIntArraysView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizedUIntArraysView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizedUIntArraysView( Container &&emboss_reserved_local_container) {
+  return GenericSizedUIntArraysView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1245,6 +1279,40 @@ MakeAlignedSizedIntArraysView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizedIntArraysView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizedIntArraysView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizedIntArraysView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizedIntArraysView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizedIntArraysView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizedIntArraysView( Container &&emboss_reserved_local_container) {
+  return GenericSizedIntArraysView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -1844,6 +1912,40 @@ MakeAlignedSizedEnumArraysView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizedEnumArraysView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizedEnumArraysView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizedEnumArraysView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizedEnumArraysView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizedEnumArraysView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizedEnumArraysView( Container &&emboss_reserved_local_container) {
+  return GenericSizedEnumArraysView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace BitArrayContainer {
@@ -2258,6 +2360,40 @@ MakeAlignedBitArrayContainerView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBitArrayContainerView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBitArrayContainerView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBitArrayContainerView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBitArrayContainerView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBitArrayContainerView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBitArrayContainerView( Container &&emboss_reserved_local_container) {
+  return GenericBitArrayContainerView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 enum class Enum : ::std::uint64_t {
   VALUE1 = static_cast</**/::std::int32_t>(1LL),

--- a/testdata/golden_cpp/float.emb.h
+++ b/testdata/golden_cpp/float.emb.h
@@ -541,6 +541,40 @@ MakeAlignedFloatsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericFloatsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeFloatsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericFloatsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericFloatsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericFloatsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeFloatsView( Container &&emboss_reserved_local_container) {
+  return GenericFloatsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1039,6 +1073,40 @@ MakeAlignedDoublesView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericDoublesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeDoublesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericDoublesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericDoublesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericDoublesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeDoublesView( Container &&emboss_reserved_local_container) {
+  return GenericDoublesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Floats {

--- a/testdata/golden_cpp/imported.emb.h
+++ b/testdata/golden_cpp/imported.emb.h
@@ -451,6 +451,40 @@ MakeAlignedInnerView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericInnerView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeInnerView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericInnerView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericInnerView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericInnerView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeInnerView( Container &&emboss_reserved_local_container) {
+  return GenericInnerView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Inner {
 
 }  // namespace Inner

--- a/testdata/golden_cpp/imported_genfiles.emb.h
+++ b/testdata/golden_cpp/imported_genfiles.emb.h
@@ -452,6 +452,40 @@ MakeAlignedInnerView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericInnerView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeInnerView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericInnerView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericInnerView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericInnerView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeInnerView( Container &&emboss_reserved_local_container) {
+  return GenericInnerView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Inner {
 
 }  // namespace Inner

--- a/testdata/golden_cpp/importer.emb.h
+++ b/testdata/golden_cpp/importer.emb.h
@@ -533,6 +533,40 @@ MakeAlignedOuterView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOuterView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOuterView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOuterView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOuterView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOuterView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOuterView( Container &&emboss_reserved_local_container) {
+  return GenericOuterView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Outer {
 
 }  // namespace Outer

--- a/testdata/golden_cpp/importer2.emb.h
+++ b/testdata/golden_cpp/importer2.emb.h
@@ -451,6 +451,40 @@ MakeAlignedOuter2View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOuter2View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOuter2View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOuter2View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOuter2View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOuter2View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOuter2View( Container &&emboss_reserved_local_container) {
+  return GenericOuter2View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Outer2 {
 
 }  // namespace Outer2

--- a/testdata/golden_cpp/inline_type.emb.h
+++ b/testdata/golden_cpp/inline_type.emb.h
@@ -716,6 +716,40 @@ MakeAlignedFooView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericFooView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeFooView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericFooView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericFooView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericFooView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeFooView( Container &&emboss_reserved_local_container) {
+  return GenericFooView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Foo {
 
 

--- a/testdata/golden_cpp/int_sizes.emb.h
+++ b/testdata/golden_cpp/int_sizes.emb.h
@@ -1025,6 +1025,40 @@ MakeAlignedSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizesView( Container &&emboss_reserved_local_container) {
+  return GenericSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Sizes {
 
 }  // namespace Sizes

--- a/testdata/golden_cpp/large_array.emb.h
+++ b/testdata/golden_cpp/large_array.emb.h
@@ -568,6 +568,40 @@ MakeAlignedUIntArrayView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericUIntArrayView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeUIntArrayView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericUIntArrayView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericUIntArrayView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericUIntArrayView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeUIntArrayView( Container &&emboss_reserved_local_container) {
+  return GenericUIntArrayView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace UIntArray {
 
 }  // namespace UIntArray

--- a/testdata/golden_cpp/nested_structure.emb.h
+++ b/testdata/golden_cpp/nested_structure.emb.h
@@ -627,6 +627,40 @@ MakeAlignedContainerView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericContainerView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeContainerView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericContainerView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericContainerView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericContainerView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeContainerView( Container &&emboss_reserved_local_container) {
+  return GenericContainerView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1125,6 +1159,40 @@ MakeAlignedBoxView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBoxView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBoxView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBoxView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBoxView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBoxView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBoxView( Container &&emboss_reserved_local_container) {
+  return GenericBoxView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -1627,6 +1695,40 @@ MakeAlignedTruckView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericTruckView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeTruckView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericTruckView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericTruckView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericTruckView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeTruckView( Container &&emboss_reserved_local_container) {
+  return GenericTruckView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Container {

--- a/testdata/golden_cpp/next_keyword.emb.h
+++ b/testdata/golden_cpp/next_keyword.emb.h
@@ -697,6 +697,40 @@ MakeAlignedNextKeywordView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericNextKeywordView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeNextKeywordView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericNextKeywordView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericNextKeywordView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericNextKeywordView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeNextKeywordView( Container &&emboss_reserved_local_container) {
+  return GenericNextKeywordView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace NextKeyword {
 
 }  // namespace NextKeyword

--- a/testdata/golden_cpp/no_enum_traits.emb.h
+++ b/testdata/golden_cpp/no_enum_traits.emb.h
@@ -531,6 +531,40 @@ MakeAlignedBarView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBarView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBarView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBarView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBarView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBarView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBarView( Container &&emboss_reserved_local_container) {
+  return GenericBarView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace Bar {
 
 }  // namespace Bar

--- a/testdata/golden_cpp/parameters.emb.h
+++ b/testdata/golden_cpp/parameters.emb.h
@@ -1067,6 +1067,40 @@ MakeAlignedMultiVersionView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericMultiVersionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeMultiVersionView(::emboss::test::Product product,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericMultiVersionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::emboss::test::Product>(product), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericMultiVersionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericMultiVersionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeMultiVersionView(::emboss::test::Product product,  Container &&emboss_reserved_local_container) {
+  return GenericMultiVersionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::emboss::test::Product>(product), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1896,6 +1930,40 @@ MakeAlignedAxesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAxesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAxesView(::std::int32_t axes,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAxesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::std::int32_t>(axes), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAxesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAxesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAxesView(::std::int32_t axes,  Container &&emboss_reserved_local_container) {
+  return GenericAxesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::std::int32_t>(axes), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2658,6 +2726,40 @@ MakeAlignedAxisPairView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAxisPairView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAxisPairView(::emboss::test::AxisType axis_type_a_parameter, ::emboss::test::AxisType axis_type_b_parameter,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAxisPairView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::emboss::test::AxisType>(axis_type_a_parameter),::std::forward</**/::emboss::test::AxisType>(axis_type_b_parameter), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAxisPairView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAxisPairView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAxisPairView(::emboss::test::AxisType axis_type_a_parameter, ::emboss::test::AxisType axis_type_b_parameter,  Container &&emboss_reserved_local_container) {
+  return GenericAxisPairView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::emboss::test::AxisType>(axis_type_a_parameter),::std::forward</**/::emboss::test::AxisType>(axis_type_b_parameter), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -3185,6 +3287,40 @@ MakeAlignedAxesEnvelopeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAxesEnvelopeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAxesEnvelopeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAxesEnvelopeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAxesEnvelopeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAxesEnvelopeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAxesEnvelopeView( Container &&emboss_reserved_local_container) {
+  return GenericAxesEnvelopeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 enum class AxisType : ::std::int64_t {
   GENERIC = static_cast</**/::std::int32_t>(-1LL),
@@ -4089,6 +4225,40 @@ MakeAlignedAxisView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAxisView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAxisView(::emboss::test::AxisType axis_type_parameter,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAxisView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::emboss::test::AxisType>(axis_type_parameter), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAxisView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAxisView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAxisView(::emboss::test::AxisType axis_type_parameter,  Container &&emboss_reserved_local_container) {
+  return GenericAxisView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::emboss::test::AxisType>(axis_type_parameter), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace Config {
@@ -4505,6 +4675,40 @@ MakeAlignedConfigView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConfigView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConfigView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConfigView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConfigView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConfigView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConfigView( Container &&emboss_reserved_local_container) {
+  return GenericConfigView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4929,6 +5133,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace ConfigVX
@@ -5435,6 +5673,40 @@ MakeAlignedConfigVXView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConfigVXView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConfigVXView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConfigVXView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConfigVXView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConfigVXView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConfigVXView( Container &&emboss_reserved_local_container) {
+  return GenericConfigVXView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace StructWithUnusedParameter {
@@ -5895,6 +6167,40 @@ MakeAlignedStructWithUnusedParameterView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
       ::std::forward</**/::std::int32_t>(x), emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructWithUnusedParameterView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructWithUnusedParameterView(::std::int32_t x,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructWithUnusedParameterView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::std::int32_t>(x), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructWithUnusedParameterView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructWithUnusedParameterView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructWithUnusedParameterView(::std::int32_t x,  Container &&emboss_reserved_local_container) {
+  return GenericStructWithUnusedParameterView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::std::int32_t>(x), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -6393,6 +6699,40 @@ MakeAlignedStructContainingStructWithUnusedParameterView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructContainingStructWithUnusedParameterView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructContainingStructWithUnusedParameterView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructContainingStructWithUnusedParameterView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructContainingStructWithUnusedParameterView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructContainingStructWithUnusedParameterView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructContainingStructWithUnusedParameterView( Container &&emboss_reserved_local_container) {
+  return GenericStructContainingStructWithUnusedParameterView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -6947,6 +7287,40 @@ MakeAlignedBiasedValueView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBiasedValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBiasedValueView(::std::int32_t bias,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBiasedValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::std::int32_t>(bias), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBiasedValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBiasedValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBiasedValueView(::std::int32_t bias,  Container &&emboss_reserved_local_container) {
+  return GenericBiasedValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::std::int32_t>(bias), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -7457,6 +7831,40 @@ MakeAlignedVirtualFirstFieldWithParamView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
       ::std::forward</**/::std::int32_t>(param), emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericVirtualFirstFieldWithParamView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeVirtualFirstFieldWithParamView(::std::int32_t param,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericVirtualFirstFieldWithParamView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::std::int32_t>(param), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericVirtualFirstFieldWithParamView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericVirtualFirstFieldWithParamView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeVirtualFirstFieldWithParamView(::std::int32_t param,  Container &&emboss_reserved_local_container) {
+  return GenericVirtualFirstFieldWithParamView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::std::int32_t>(param), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -7978,6 +8386,40 @@ MakeAlignedConstVirtualFirstFieldWithParamView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
       ::std::forward</**/::std::int32_t>(param), emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericConstVirtualFirstFieldWithParamView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeConstVirtualFirstFieldWithParamView(::std::int32_t param,  Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericConstVirtualFirstFieldWithParamView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+      ::std::forward</**/::std::int32_t>(param), ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericConstVirtualFirstFieldWithParamView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericConstVirtualFirstFieldWithParamView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeConstVirtualFirstFieldWithParamView(::std::int32_t param,  Container &&emboss_reserved_local_container) {
+  return GenericConstVirtualFirstFieldWithParamView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+      ::std::forward</**/::std::int32_t>(param), ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -8592,6 +9034,40 @@ MakeAlignedSizedArrayOfBiasedValuesView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizedArrayOfBiasedValuesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizedArrayOfBiasedValuesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizedArrayOfBiasedValuesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizedArrayOfBiasedValuesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizedArrayOfBiasedValuesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizedArrayOfBiasedValuesView( Container &&emboss_reserved_local_container) {
+  return GenericSizedArrayOfBiasedValuesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace MultiVersion {

--- a/testdata/golden_cpp/requires.emb.h
+++ b/testdata/golden_cpp/requires.emb.h
@@ -1070,6 +1070,40 @@ MakeAlignedRequiresIntegersView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRequiresIntegersView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRequiresIntegersView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRequiresIntegersView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRequiresIntegersView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRequiresIntegersView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRequiresIntegersView( Container &&emboss_reserved_local_container) {
+  return GenericRequiresIntegersView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1768,6 +1802,40 @@ MakeAlignedEmbossReservedAnonymousField2View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField2View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField2View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField2View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField2View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField2View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace RequiresBools
@@ -2558,6 +2626,40 @@ MakeAlignedRequiresBoolsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRequiresBoolsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRequiresBoolsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRequiresBoolsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRequiresBoolsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRequiresBoolsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRequiresBoolsView( Container &&emboss_reserved_local_container) {
+  return GenericRequiresBoolsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -3488,6 +3590,40 @@ MakeAlignedRequiresEnumsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRequiresEnumsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRequiresEnumsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRequiresEnumsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRequiresEnumsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRequiresEnumsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRequiresEnumsView( Container &&emboss_reserved_local_container) {
+  return GenericRequiresEnumsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -4202,6 +4338,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace RequiresWithOptionalFields
 
 
@@ -4773,6 +4943,40 @@ MakeAlignedRequiresWithOptionalFieldsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRequiresWithOptionalFieldsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRequiresWithOptionalFieldsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRequiresWithOptionalFieldsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRequiresWithOptionalFieldsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRequiresWithOptionalFieldsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRequiresWithOptionalFieldsView( Container &&emboss_reserved_local_container) {
+  return GenericRequiresWithOptionalFieldsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 namespace RequiresInArrayElements {
@@ -5208,6 +5412,40 @@ MakeAlignedElementView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericElementView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeElementView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericElementView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericElementView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericElementView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeElementView( Container &&emboss_reserved_local_container) {
+  return GenericElementView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace RequiresInArrayElements
 
 
@@ -5622,6 +5860,40 @@ MakeAlignedRequiresInArrayElementsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRequiresInArrayElementsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRequiresInArrayElementsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRequiresInArrayElementsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRequiresInArrayElementsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRequiresInArrayElementsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRequiresInArrayElementsView( Container &&emboss_reserved_local_container) {
+  return GenericRequiresInArrayElementsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace RequiresIntegers {

--- a/testdata/golden_cpp/start_size_range.emb.h
+++ b/testdata/golden_cpp/start_size_range.emb.h
@@ -733,6 +733,40 @@ MakeAlignedStartSizeView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStartSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStartSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStartSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStartSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStartSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStartSizeView( Container &&emboss_reserved_local_container) {
+  return GenericStartSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 namespace StartSize {
 
 }  // namespace StartSize

--- a/testdata/golden_cpp/subtypes.emb.h
+++ b/testdata/golden_cpp/subtypes.emb.h
@@ -725,6 +725,40 @@ MakeAlignedInInView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericInInView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeInInView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericInInView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericInInView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericInInView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeInInView( Container &&emboss_reserved_local_container) {
+  return GenericInInView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace In
 
 
@@ -1569,6 +1603,40 @@ MakeAlignedInView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericInView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeInView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericInView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericInView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericInView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeInView( Container &&emboss_reserved_local_container) {
+  return GenericInView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1986,6 +2054,40 @@ MakeAlignedIn2View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericIn2View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeIn2View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericIn2View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericIn2View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericIn2View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeIn2View( Container &&emboss_reserved_local_container) {
+  return GenericIn2View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace Out
@@ -2961,6 +3063,40 @@ MakeAlignedOutView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericOutView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeOutView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericOutView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericOutView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericOutView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeOutView( Container &&emboss_reserved_local_container) {
+  return GenericOutView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Out {

--- a/testdata/golden_cpp/text_format.emb.h
+++ b/testdata/golden_cpp/text_format.emb.h
@@ -549,6 +549,40 @@ MakeAlignedVanillaView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericVanillaView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeVanillaView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericVanillaView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericVanillaView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericVanillaView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeVanillaView( Container &&emboss_reserved_local_container) {
+  return GenericVanillaView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1101,6 +1135,40 @@ MakeAlignedStructWithSkippedFieldsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructWithSkippedFieldsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructWithSkippedFieldsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructWithSkippedFieldsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructWithSkippedFieldsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructWithSkippedFieldsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructWithSkippedFieldsView( Container &&emboss_reserved_local_container) {
+  return GenericStructWithSkippedFieldsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -1645,6 +1713,40 @@ MakeAlignedStructWithSkippedStructureFieldsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructWithSkippedStructureFieldsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructWithSkippedStructureFieldsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructWithSkippedStructureFieldsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructWithSkippedStructureFieldsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructWithSkippedStructureFieldsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructWithSkippedStructureFieldsView( Container &&emboss_reserved_local_container) {
+  return GenericStructWithSkippedStructureFieldsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Vanilla {

--- a/testdata/golden_cpp/uint_sizes.emb.h
+++ b/testdata/golden_cpp/uint_sizes.emb.h
@@ -1077,6 +1077,40 @@ MakeAlignedSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSizesView( Container &&emboss_reserved_local_container) {
+  return GenericSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2069,6 +2103,40 @@ MakeAlignedBigEndianSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBigEndianSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBigEndianSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBigEndianSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBigEndianSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBigEndianSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBigEndianSizesView( Container &&emboss_reserved_local_container) {
+  return GenericBigEndianSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -3059,6 +3127,40 @@ MakeAlignedAlternatingEndianSizesView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericAlternatingEndianSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeAlternatingEndianSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericAlternatingEndianSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericAlternatingEndianSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericAlternatingEndianSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeAlternatingEndianSizesView( Container &&emboss_reserved_local_container) {
+  return GenericAlternatingEndianSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4061,6 +4163,40 @@ MakeAlignedEnumSizesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEnumSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEnumSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEnumSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEnumSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEnumSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEnumSizesView( Container &&emboss_reserved_local_container) {
+  return GenericEnumSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -4486,6 +4622,40 @@ MakeAlignedEmbossReservedAnonymousField1View(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeEmbossReservedAnonymousField1View( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericEmbossReservedAnonymousField1View<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericEmbossReservedAnonymousField1View<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeEmbossReservedAnonymousField1View( Container &&emboss_reserved_local_container) {
+  return GenericEmbossReservedAnonymousField1View<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace ExplicitlySizedEnumSizes
@@ -5155,6 +5325,40 @@ MakeAlignedExplicitlySizedEnumSizesView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericExplicitlySizedEnumSizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeExplicitlySizedEnumSizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericExplicitlySizedEnumSizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericExplicitlySizedEnumSizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericExplicitlySizedEnumSizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeExplicitlySizedEnumSizesView( Container &&emboss_reserved_local_container) {
+  return GenericExplicitlySizedEnumSizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 enum class Enum : ::std::uint64_t {
   VALUE1 = static_cast</**/::std::int32_t>(1LL),
@@ -6473,6 +6677,40 @@ MakeAlignedArraySizesView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericArraySizesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeArraySizesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericArraySizesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericArraySizesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericArraySizesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeArraySizesView( Container &&emboss_reserved_local_container) {
+  return GenericArraySizesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace Sizes {

--- a/testdata/golden_cpp/virtual_field.emb.h
+++ b/testdata/golden_cpp/virtual_field.emb.h
@@ -1118,6 +1118,40 @@ MakeAlignedStructureWithConstantsView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithConstantsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithConstantsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithConstantsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithConstantsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithConstantsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithConstantsView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithConstantsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2152,6 +2186,40 @@ MakeAlignedStructureWithComputedValuesView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithComputedValuesView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithComputedValuesView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithComputedValuesView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithComputedValuesView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithComputedValuesView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithComputedValuesView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithComputedValuesView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -2792,6 +2860,40 @@ MakeAlignedStructureWithConditionalValueView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithConditionalValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithConditionalValueView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithConditionalValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithConditionalValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithConditionalValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithConditionalValueView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithConditionalValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -3408,6 +3510,40 @@ MakeAlignedStructureWithValueInConditionView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithValueInConditionView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithValueInConditionView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithValueInConditionView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithValueInConditionView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithValueInConditionView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithValueInConditionView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithValueInConditionView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -4112,6 +4248,40 @@ MakeAlignedStructureWithValuesInLocationView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithValuesInLocationView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithValuesInLocationView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithValuesInLocationView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithValuesInLocationView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithValuesInLocationView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithValuesInLocationView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithValuesInLocationView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -4616,6 +4786,40 @@ MakeAlignedStructureWithBoolValueView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithBoolValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithBoolValueView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithBoolValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithBoolValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithBoolValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithBoolValueView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithBoolValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -5212,6 +5416,40 @@ MakeAlignedStructureWithEnumValueView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithEnumValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithEnumValueView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithEnumValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithEnumValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithEnumValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithEnumValueView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithEnumValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -5763,6 +6001,40 @@ MakeAlignedStructureWithBitsWithValueView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureWithBitsWithValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureWithBitsWithValueView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureWithBitsWithValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureWithBitsWithValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureWithBitsWithValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureWithBitsWithValueView( Container &&emboss_reserved_local_container) {
+  return GenericStructureWithBitsWithValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -6355,6 +6627,40 @@ MakeAlignedBitsWithValueView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericBitsWithValueView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeBitsWithValueView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericBitsWithValueView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericBitsWithValueView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericBitsWithValueView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeBitsWithValueView( Container &&emboss_reserved_local_container) {
+  return GenericBitsWithValueView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -6830,6 +7136,40 @@ MakeAlignedStructureUsingForeignConstantsView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericStructureUsingForeignConstantsView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeStructureUsingForeignConstantsView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericStructureUsingForeignConstantsView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericStructureUsingForeignConstantsView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericStructureUsingForeignConstantsView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeStructureUsingForeignConstantsView( Container &&emboss_reserved_local_container) {
+  return GenericStructureUsingForeignConstantsView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -7336,6 +7676,40 @@ MakeAlignedHeaderView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericHeaderView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeHeaderView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericHeaderView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericHeaderView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericHeaderView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeHeaderView( Container &&emboss_reserved_local_container) {
+  return GenericHeaderView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace SubfieldOfAlias
@@ -7846,6 +8220,40 @@ MakeAlignedSubfieldOfAliasView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericSubfieldOfAliasView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeSubfieldOfAliasView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericSubfieldOfAliasView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericSubfieldOfAliasView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericSubfieldOfAliasView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeSubfieldOfAliasView( Container &&emboss_reserved_local_container) {
+  return GenericSubfieldOfAliasView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -8396,6 +8804,40 @@ MakeAlignedRestrictedAliasView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRestrictedAliasView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRestrictedAliasView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRestrictedAliasView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRestrictedAliasView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRestrictedAliasView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRestrictedAliasView( Container &&emboss_reserved_local_container) {
+  return GenericRestrictedAliasView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -8931,6 +9373,40 @@ MakeAlignedXView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericXView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeXView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericXView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericXView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericXView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeXView( Container &&emboss_reserved_local_container) {
+  return GenericXView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 }  // namespace HasField
@@ -9590,6 +10066,40 @@ MakeAlignedHasFieldView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericHasFieldView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeHasFieldView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericHasFieldView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericHasFieldView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericHasFieldView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeHasFieldView( Container &&emboss_reserved_local_container) {
+  return GenericHasFieldView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -10212,6 +10722,40 @@ MakeAlignedVirtualUnconditionallyUsesConditionalView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericVirtualUnconditionallyUsesConditionalView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeVirtualUnconditionallyUsesConditionalView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericVirtualUnconditionallyUsesConditionalView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericVirtualUnconditionallyUsesConditionalView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericVirtualUnconditionallyUsesConditionalView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeVirtualUnconditionallyUsesConditionalView( Container &&emboss_reserved_local_container) {
+  return GenericVirtualUnconditionallyUsesConditionalView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -10723,6 +11267,40 @@ MakeAlignedRView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericRView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeRView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericRView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericRView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericRView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeRView( Container &&emboss_reserved_local_container) {
+  return GenericRView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 }  // namespace UsesSize
 
 
@@ -11222,6 +11800,40 @@ MakeAlignedUsesSizeView(
       emboss_reserved_local_size);
 }
 
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericUsesSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeUsesSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericUsesSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericUsesSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericUsesSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeUsesSizeView( Container &&emboss_reserved_local_container) {
+  return GenericUsesSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
+}
+
 
 
 
@@ -11716,6 +12328,40 @@ MakeAlignedUsesExternalSizeView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericUsesExternalSizeView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeUsesExternalSizeView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericUsesExternalSizeView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericUsesExternalSizeView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericUsesExternalSizeView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeUsesExternalSizeView( Container &&emboss_reserved_local_container) {
+  return GenericUsesExternalSizeView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 
@@ -12805,6 +13451,40 @@ MakeAlignedImplicitWriteBackView(
       /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
        emboss_reserved_local_data,
       emboss_reserved_local_size);
+}
+
+template <typename Iterator,
+          typename = typename ::std::enable_if<
+              !::std::is_pointer<Iterator>::value>::type>
+inline GenericImplicitWriteBackView<
+    /**/ ::emboss::support::IteratorStorage<Iterator>>
+MakeImplicitWriteBackView( Iterator emboss_reserved_local_begin,
+                Iterator emboss_reserved_local_end) {
+  return GenericImplicitWriteBackView<
+      /**/ ::emboss::support::IteratorStorage<Iterator>>(
+       ::emboss::support::IteratorStorage<Iterator>(
+          ::std::move(emboss_reserved_local_begin),
+          ::std::move(emboss_reserved_local_end)));
+}
+
+template <typename Container,
+          typename = typename ::std::enable_if<
+              !EmbossReservedInternalIsGenericImplicitWriteBackView<
+                  typename ::std::remove_cv<typename ::std::remove_reference<
+                      Container>::type>::type>::value &&
+              !::std::is_pointer<typename ::std::remove_reference<
+                  Container>::type>::value>::type>
+inline GenericImplicitWriteBackView<
+    /**/ ::emboss::support::IteratorStorage<
+        decltype(::std::begin(::std::declval<Container &>()))>>
+MakeImplicitWriteBackView( Container &&emboss_reserved_local_container) {
+  return GenericImplicitWriteBackView<
+      /**/ ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>>(
+       ::emboss::support::IteratorStorage<
+          decltype(::std::begin(::std::declval<Container &>()))>(
+          ::std::begin(emboss_reserved_local_container),
+          ::std::end(emboss_reserved_local_container)));
 }
 
 namespace StructureWithConstants {


### PR DESCRIPTION
Add support for views over non-contiguous containers, allowing direct access and mutation via iterators. Iterator access is slower than contiguous containers, as currently there is no support for communicating contiguity metadata to the Emboss runtime support, but if that information is surfaced in the future as an optimization then it can defer to contiguous `MemoryAccessor`s for copies that are not across a contiguity boundary, which should improve performance.

This should not have an effect on existing contiguous containers as they continue to use contiguous memory access and `std::copy_n` will optimize to `memcpy` in all major compilers.

Contains the following commits:

---
### Introduce noncontiguous container utility

Introduce a test utility type that is a non-contiguous container that is
highly configurable in structure so we can test various conditions in
upcoming features.

---
### Add UnalignedAccessor to read/write through iterator

This enables accessing values in generic functionality that works
through any iterator, allowing transparent `memcpy` performance for
pointers (all major compilers will compile `std::copy_n` for a
`char`-like pointer into a memcpy), while supporting arbitrary
iterators.

Added tests that exhaustively test various possible non-contiguous
arrangements.

---
### Introduce IteratorStorage for any iterable

Create a storage type for arbitrary iteratable types, technically
supporting contiguous buffers, though continue to keep contiguous
buffers as it is much more performant for contiguous access.

---
### Add support for IteratorStorage to Make[Struct]View

Enable creating a struct view over non-contiguous containers using the
Make[Struct]View generated functions.