### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/verify-pull-request.yml
+++ b/.github/workflows/verify-pull-request.yml
@@ -10,7 +10,7 @@ jobs:
         cpp-compiler: ["clang", "gcc"]
         options: ["-c opt", ""]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           bazelisk-cache: true
@@ -22,7 +22,7 @@ jobs:
     name: "Check Python formatting"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
@@ -31,7 +31,7 @@ jobs:
     name: "Check build.json"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: bazel-contrib/setup-bazel@0.8.5
         with:
           bazelisk-cache: true


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v4...v6) | verify-pull-request.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Release Notes

<details>
<summary>Release notes for actions/checkout</summary>

### [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)

## What's Changed
* Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by @TingluoHuang in https://github.com/actions/checkout/pull/2355
* Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356

**Full Changelog**: https://github.com/actions/checkout/compare/v6.0.1...v6.0.2

### [v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)

## What's Changed
* Update all references from v5 and v4 to v6 by @ericsciple in https://github.com/actions/checkout/pull/2314
* Add worktree support for persist-credentials includeIf by @ericsciple in https://github.com/actions/checkout/pull/2327
* Clarify v6 README by @ericsciple in https://github.com/actions/checkout/pull/2328


**Full Changelog**: https://github.com/actions/checkout/compare/v6...v6.0.1

### [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

## What's Changed
* Update README to include Node.js 24 support details and requirements by @salmanmkc in https://github.com/actions/checkout/pull/2248
* Persist creds to a separate file by @ericsciple in https://github.com/actions/checkout/pull/2286
* v6-beta by @ericsciple in https://github.com/actions/checkout/pull/2298
* update readme/changelog for v6 by @ericsciple in https://github.com/actions/checkout/pull/2311


**Full Changelog**: https://github.com/actions/checkout/compare/v5.0.

*...truncated*

### [v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)

## What's Changed
* Port v6 cleanup to v5 by @ericsciple in https://github.com/actions/checkout/pull/2301


**Full Changelog**: https://github.com/actions/checkout/compare/v5...v5.0.1

### [v4.3.1](https://github.com/actions/checkout/releases/tag/v4.3.1)

## What's Changed
* Port v6 cleanup to v4 by @ericsciple in https://github.com/actions/checkout/pull/2305


**Full Changelog**: https://github.com/actions/checkout/compare/v4...v4.3.1

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
