### PR TITLE
Render switch discriminant once per group; drop dead inner scope

### DIFF
--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -402,7 +402,6 @@ ${write_fields}
 // ** ok_method_switch_block ** ////////////////////////////////////////////////
     // Check fields that depend on a common discriminant using a switch.
     {
-${inner_scope_definitions}
       const auto emboss_reserved_switch_discrim = ${discriminant};
       if (!emboss_reserved_switch_discrim.Known()) return false;
       switch (emboss_reserved_switch_discrim.ValueOrDefault()) {

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -412,10 +412,8 @@ ${switch_cases}
     }
 
 
-// ** ok_method_switch_case ** /////////////////////////////////////////////////
-        case ${case_value}:
-          if (!${field}().Ok()) return false;
-          break;
+// ** ok_method_switch_arm ** //////////////////////////////////////////////////
+${case_labels}${case_body}          break;
 
 
 

--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -1457,14 +1457,19 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     for field in fields:
         discrim_expr, case_expr = _get_switch_candidate(field.existence_condition, ir)
         if discrim_expr:
-            discrim_str = _render_expression(
-                discrim_expr, ir, subexpressions=None
+            # Render the discriminant once into the active subexpression scope.
+            # The rendered string is stable for equivalent discriminants (the
+            # scope dedupes by the inner rendered form), so it doubles as a
+            # grouping key and as the C++ to emit later. This avoids a second
+            # IR traversal at emit time for every switch group.
+            discrim_rendered = _render_expression(
+                discrim_expr, ir, subexpressions=subexpressions
             ).rendered
-            key = "SWITCH:" + discrim_str
+            key = "SWITCH:" + discrim_rendered
             if key not in groups:
                 groups[key] = {
                     "type": "switch",
-                    "expr": discrim_expr,
+                    "discrim_rendered": discrim_rendered,
                     "cases": [],
                     "seen_cases": set(),
                 }
@@ -1482,7 +1487,6 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
                 if if_key not in groups:
                     groups[if_key] = {
                         "type": "if",
-                        "expr": field.existence_condition,
                         "fields": [],
                     }
                     ordered_keys.append(if_key)
@@ -1495,7 +1499,6 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
             if key not in groups:
                 groups[key] = {
                     "type": "if",
-                    "expr": field.existence_condition,
                     "fields": [],
                 }
                 ordered_keys.append(key)
@@ -1505,14 +1508,6 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     for key in ordered_keys:
         group = groups[key]
         if group["type"] == "switch":
-            discrim_rendered = _render_expression(
-                group["expr"], ir, subexpressions=subexpressions
-            ).rendered
-            # Create a new scope for the switch block
-            inner_scope = ExpressionScope(
-                "emboss_reserved_switch_scope_", parent=subexpressions
-            )
-
             # Generate switch cases using template
             switch_cases = []
             for case_val, field in group["cases"]:
@@ -1527,8 +1522,7 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
             blocks.append(
                 code_template.format_template(
                     _TEMPLATES.ok_method_switch_block,
-                    inner_scope_definitions=inner_scope.definition_code().rstrip(),
-                    discriminant=discrim_rendered,
+                    discriminant=group["discrim_rendered"],
                     switch_cases="".join(switch_cases),
                 )
             )

--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -1364,6 +1364,22 @@ def _render_case_label(expression, ir):
         assert False, "Unsupported switch case type"
 
 
+def _case_sort_key(expression):
+    """Returns the underlying integer value of a switch case expression.
+
+    Used to sort case labels within a switch so the emitted C++ presents cases
+    in monotonic order. Compilers (particularly the older GCCs in many
+    embedded toolchains) are more likely to generate a dense jump table when
+    cases are sorted.
+    """
+    if expression.type.which_type == "integer":
+        return int(expression.type.integer.modular_value)
+    elif expression.type.which_type == "enumeration":
+        return int(expression.type.enumeration.value)
+    else:
+        assert False, "Unsupported switch case type"
+
+
 def _get_switch_candidate(expression, ir):
     """Returns (discriminant_expr, case_value_expr) or (None, None)."""
     if not _is_equality_check(expression):
@@ -1470,27 +1486,14 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
                 groups[key] = {
                     "type": "switch",
                     "discrim_rendered": discrim_rendered,
-                    "cases": [],
-                    "seen_cases": set(),
+                    "cases_by_label": {},
                 }
                 ordered_keys.append(key)
-
             case_str = _render_case_label(case_expr, ir)
-            if case_str not in groups[key]["seen_cases"]:
-                groups[key]["seen_cases"].add(case_str)
-                groups[key]["cases"].append((case_str, field))
-            else:
-                cond_res = _render_expression(
-                    field.existence_condition, ir, subexpressions=None
-                )
-                if_key = "IF:" + cond_res.rendered
-                if if_key not in groups:
-                    groups[if_key] = {
-                        "type": "if",
-                        "fields": [],
-                    }
-                    ordered_keys.append(if_key)
-                groups[if_key]["fields"].append(field)
+            case_entry = groups[key]["cases_by_label"].setdefault(
+                case_str, {"sort_key": _case_sort_key(case_expr), "fields": []}
+            )
+            case_entry["fields"].append(field)
         else:
             cond_res = _render_expression(
                 field.existence_condition, ir, subexpressions=None
@@ -1508,24 +1511,7 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     for key in ordered_keys:
         group = groups[key]
         if group["type"] == "switch":
-            # Generate switch cases using template
-            switch_cases = []
-            for case_val, field in group["cases"]:
-                switch_cases.append(
-                    code_template.format_template(
-                        _TEMPLATES.ok_method_switch_case,
-                        case_value=case_val,
-                        field=_cpp_field_name(field.name.name.text),
-                    )
-                )
-
-            blocks.append(
-                code_template.format_template(
-                    _TEMPLATES.ok_method_switch_block,
-                    discriminant=group["discrim_rendered"],
-                    switch_cases="".join(switch_cases),
-                )
-            )
+            blocks.append(_emit_switch_block(group))
         else:
             for field in group["fields"]:
                 blocks.append(
@@ -1536,6 +1522,62 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
                 )
 
     return "".join(blocks)
+
+
+def _render_case_body(fields):
+    """Renders the body of a single switch arm — the field validation tests."""
+    return "".join(
+        "          if (!{}().Ok()) return false;\n".format(
+            _cpp_field_name(f.name.name.text)
+        )
+        for f in fields
+    )
+
+
+def _emit_switch_block(group):
+    """Emits a complete switch block from a collected switch group.
+
+    Performs case-label sorting and identical-body coalescing:
+
+      * Case labels within an arm are sorted by underlying numeric value, so
+        the C++ compiler is presented with monotonic case sequences and is
+        more likely to emit a dense jump table on embedded targets.
+      * Distinct case values whose bodies are textually identical (which
+        happens when several disjuncts of `||` guard the same field, or when
+        multiple fields share an existence condition) are merged into a
+        single multi-label arm, so the compiler emits one body for all of
+        them rather than duplicating per case.
+    """
+    body_to_labels = {}
+    body_first_seen = {}
+    for case_str, case_entry in group["cases_by_label"].items():
+        body = _render_case_body(case_entry["fields"])
+        body_to_labels.setdefault(body, []).append((case_entry["sort_key"], case_str))
+        if body not in body_first_seen:
+            body_first_seen[body] = case_entry["sort_key"]
+
+    arms = []
+    for body, labels in body_to_labels.items():
+        labels.sort()  # by (sort_key, case_str)
+        arms.append((body_first_seen[body], labels, body))
+    arms.sort(key=lambda arm: arm[0])
+
+    rendered_arms = []
+    for _, labels, body in arms:
+        case_labels = "".join("        case {}:\n".format(cs) for _, cs in labels)
+        rendered_arms.append(
+            code_template.format_template(
+                _TEMPLATES.ok_method_switch_arm,
+                case_labels=case_labels,
+                case_body=body,
+            )
+        )
+
+    return code_template.format_template(
+        _TEMPLATES.ok_method_switch_block,
+        discriminant=group["discrim_rendered"],
+        switch_cases="".join(rendered_arms),
+    )
 
 
 def _generate_structure_definition(type_ir, ir, config: Config):

--- a/testdata/golden_cpp/many_conditionals.emb.h
+++ b/testdata/golden_cpp/many_conditionals.emb.h
@@ -97,6 +97,7 @@ class GenericLargeConditionalsView final {
       switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
         case static_cast</**/ ::std::int32_t>(0LL):
           if (!f0().Ok()) return false;
+          if (!f0_copy().Ok()) return false;
           break;
 
         case static_cast</**/ ::std::int32_t>(1LL):
@@ -499,9 +500,6 @@ class GenericLargeConditionalsView final {
           break;
       }
     }
-
-    if (!has_f0_copy().Known()) return false;
-    if (has_f0_copy().ValueOrDefault() && !f0_copy().Ok()) return false;
 
     return true;
   }


### PR DESCRIPTION
The optimized `Ok()` switch-block code in `_generate_optimized_ok_method_body` was rendering each switch group's discriminant twice — once unscoped at grouping time to build the SWITCH key, and again with the active `ExpressionScope` at emit time. Render it once with the scope and reuse the result. Because `ExpressionScope.add` dedupes by inner rendered form, the result is stable for equivalent discriminants and still works as a grouping key.

The `ok_method_switch_block` template's `${inner_scope_definitions}` placeholder was unused — the inner `ExpressionScope` it referenced had nothing added to it. Removed both, which also drops the blank line each switch block was carrying in the goldens.

Pure compile-time cleanup; no behavioral change.

### Size impact

| Target | Metric | Master | PR | Delta |
|---|---|---:|---:|---:|
| ARM Thumb-2 | TU .text | 18962 | 18962 | 0 (0.0%) |
| MicroBlaze | TU .text | 43640 | 43640 | 0 (0.0%) |
| Host x86-64 | TU .text | 29166 | 29166 | 0 (0.0%) |

Foundation for #254 / #256 / #257 / #258 / #259 (see those for the wins this enables).