### PR TITLE
Extend switch matcher: disjunction, conjunction, single-entry demotion

### DIFF
--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -1403,6 +1403,116 @@ def _get_switch_candidate(expression, ir):
     return None, None
 
 
+def _flatten_function(expression, function):
+    """Flatten a binary function chain into a flat list of operands.
+
+    Both `(a OP b) OP c` and `a OP (b OP c)` flatten to `[a, b, c]`.
+    """
+    if (
+        expression.which_expression == "function"
+        and expression.function.function == function
+    ):
+        out = []
+        for arg in expression.function.args:
+            out.extend(_flatten_function(arg, function))
+        return out
+    return [expression]
+
+
+def _flatten_or(expression):
+    return _flatten_function(expression, ir_data.FunctionMapping.OR)
+
+
+def _flatten_and(expression):
+    return _flatten_function(expression, ir_data.FunctionMapping.AND)
+
+
+def _extract_switch_arms(expression, ir):
+    """Decomposes `expression` into a list of switch arms.
+
+    Returns either:
+      * (discriminant_expr, [(case_value_expr, residual_conjuncts), ...])
+        when the expression decomposes into a switch on a single
+        discriminant. `residual_conjuncts` is an empty list when the arm
+        is a bare equality on the discriminant; otherwise it is the list
+        of additional IR sub-expressions (`AND`-conjuncts) that the arm
+        must also satisfy. Case values are returned in encounter order;
+        the caller is responsible for sorting/coalescing.
+      * (None, None) when the expression doesn't decompose into a switch.
+
+    Supported shapes:
+      * `discrim == K`                         → one arm, no residual.
+      * `discrim == K1 || discrim == K2 || …`  → one arm per Ki, no
+        residual. Common for tagged unions where several tag values
+        share a payload (`if tag == 0x10 || tag == 0x11: …`).
+      * `discrim == K && other_predicate`      → one arm with residual
+        `[other_predicate]`. Useful for nested guards like
+        `if outer_flag && tag == K:`.
+      * `(discrim == K1 || …) && other`        → multiple arms each
+        carrying `[other]` as residual.
+      * Disjunction whose disjuncts mix shapes: `(tag == 0 && a) ||
+        (tag == 1 && b) || tag == 2` → three arms with respective
+        residuals `[a]`, `[b]`, `[]`.
+
+    Residuals are rendered into the case body at emit time as an extra
+    `if (residual.ValueOrDefault())` guard around the field's `Ok()`
+    check, so the optimization stays sound for partially-Known
+    residuals (we still `return false` if the residual isn't Known()).
+    """
+    # Bare equality.
+    discrim, case_val = _get_switch_candidate(expression, ir)
+    if discrim is not None:
+        return discrim, [(case_val, [])]
+
+    # Conjunction: try each conjunct as the switch source; if exactly one
+    # extracts, the others become the residual.
+    if (
+        expression.which_expression == "function"
+        and expression.function.function == ir_data.FunctionMapping.AND
+    ):
+        conjuncts = _flatten_and(expression)
+        for i, c in enumerate(conjuncts):
+            sub = _extract_switch_arms(c, ir)
+            if sub[0] is None:
+                continue
+            other_conjuncts = [conjuncts[j] for j in range(len(conjuncts)) if j != i]
+            sub_discrim, sub_arms = sub
+            merged = [
+                (case_val, residual + other_conjuncts)
+                for (case_val, residual) in sub_arms
+            ]
+            return sub_discrim, merged
+        return None, None
+
+    # Disjunction: each disjunct must independently extract a switch on
+    # the same discriminant.
+    if (
+        expression.which_expression == "function"
+        and expression.function.function == ir_data.FunctionMapping.OR
+    ):
+        disjuncts = _flatten_or(expression)
+        common_discrim = None
+        common_discrim_str = None
+        all_arms = []
+        for d in disjuncts:
+            sub_discrim, sub_arms = _extract_switch_arms(d, ir)
+            if sub_discrim is None:
+                return None, None
+            sub_discrim_str = _render_expression(
+                sub_discrim, ir, subexpressions=None
+            ).rendered
+            if common_discrim_str is None:
+                common_discrim = sub_discrim
+                common_discrim_str = sub_discrim_str
+            elif sub_discrim_str != common_discrim_str:
+                # Disjuncts disagree on the discriminant; can't be one switch.
+                return None, None
+            all_arms.extend(sub_arms)
+        return common_discrim, all_arms
+
+    return None, None
+
+
 def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     """Generates optimized C++ code for the Ok() method body.
 
@@ -1469,31 +1579,51 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     """
     groups = {}
     ordered_keys = []
+    # Track which group each field was routed to and whether the field's
+    # arms have residuals; the demotion pass at the end uses this to fall
+    # back to ok_method_test for groups where switch-ifying isn't a net
+    # win (single-entry groups, where the switch wrapper costs more than
+    # the dedupe saves).
+    field_group_key = {}
 
     for field in fields:
-        discrim_expr, case_expr = _get_switch_candidate(field.existence_condition, ir)
+        discrim_expr, arms = _extract_switch_arms(field.existence_condition, ir)
         if discrim_expr:
-            # Render the discriminant once into the active subexpression scope.
-            # The rendered string is stable for equivalent discriminants (the
-            # scope dedupes by the inner rendered form), so it doubles as a
-            # grouping key and as the C++ to emit later. This avoids a second
-            # IR traversal at emit time for every switch group.
-            discrim_rendered = _render_expression(
-                discrim_expr, ir, subexpressions=subexpressions
+            # Render the discriminant unscoped to build the grouping key.
+            # We can't render-with-scope yet because we don't know which
+            # groups will survive demotion (see below); committing a
+            # subexpression to `subexpressions` for a group that ends up
+            # demoted would leave a dead `const auto = ...` definition in
+            # the emitted C++. The scoped render happens at emit time,
+            # only for groups that survive.
+            discrim_key = _render_expression(
+                discrim_expr, ir, subexpressions=None
             ).rendered
-            key = "SWITCH:" + discrim_rendered
+            key = "SWITCH:" + discrim_key
             if key not in groups:
                 groups[key] = {
                     "type": "switch",
-                    "discrim_rendered": discrim_rendered,
+                    "discrim_expr": discrim_expr,
                     "cases_by_label": {},
+                    "encounter_order": [],
+                    "encountered_field_ids": set(),
                 }
                 ordered_keys.append(key)
-            case_str = _render_case_label(case_expr, ir)
-            case_entry = groups[key]["cases_by_label"].setdefault(
-                case_str, {"sort_key": _case_sort_key(case_expr), "fields": []}
-            )
-            case_entry["fields"].append(field)
+            group = groups[key]
+            if id(field) not in group["encountered_field_ids"]:
+                group["encountered_field_ids"].add(id(field))
+                group["encounter_order"].append(field)
+            for case_expr, residual in arms:
+                case_str = _render_case_label(case_expr, ir)
+                case_entry = group["cases_by_label"].setdefault(
+                    case_str, {"sort_key": _case_sort_key(case_expr), "entries": []}
+                )
+                # Avoid duplicating a field across cases that map to the same
+                # case label twice (`tag == 0 || tag == 0`); after #9 the
+                # simplifier should normally prevent this from reaching us.
+                if not any(e[0] is field for e in case_entry["entries"]):
+                    case_entry["entries"].append((field, bool(residual)))
+            field_group_key[id(field)] = key
         else:
             cond_res = _render_expression(
                 field.existence_condition, ir, subexpressions=None
@@ -1506,12 +1636,46 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
                 }
                 ordered_keys.append(key)
             groups[key]["fields"].append(field)
+            field_group_key[id(field)] = key
+
+    # Demote switch groups that wouldn't actually benefit from a switch.
+    # A switch's overhead — the temporary discriminant variable, the
+    # Known() guard, the scope braces — is only worthwhile if the switch
+    # dedupes either at least two distinct case labels (sharing one
+    # subexpression read) or at least two distinct fields (sharing one
+    # discriminant evaluation). When a group has just one entry total
+    # (one field, one bare case), the unoptimized has_${field}()-based
+    # check is strictly smaller.
+    for key in ordered_keys:
+        group = groups[key]
+        if group["type"] != "switch":
+            continue
+        total_entries = sum(
+            len(case_entry["entries"])
+            for case_entry in group["cases_by_label"].values()
+        )
+        if total_entries < 2:
+            group["type"] = "demoted_to_if"
 
     blocks = []
     for key in ordered_keys:
         group = groups[key]
         if group["type"] == "switch":
+            # Now that we know this group survived demotion, render the
+            # discriminant with the active scope so it shares
+            # subexpression slots with the rest of Ok().
+            group["discrim_rendered"] = _render_expression(
+                group["discrim_expr"], ir, subexpressions=subexpressions
+            ).rendered
             blocks.append(_emit_switch_block(group))
+        elif group["type"] == "demoted_to_if":
+            for field in group["encounter_order"]:
+                blocks.append(
+                    code_template.format_template(
+                        _TEMPLATES.ok_method_test,
+                        field=_cpp_field_name(field.name.name.text),
+                    )
+                )
         else:
             for field in group["fields"]:
                 blocks.append(
@@ -1524,14 +1688,34 @@ def _generate_optimized_ok_method_body(fields, ir, subexpressions):
     return "".join(blocks)
 
 
-def _render_case_body(fields):
-    """Renders the body of a single switch arm — the field validation tests."""
-    return "".join(
-        "          if (!{}().Ok()) return false;\n".format(
-            _cpp_field_name(f.name.name.text)
-        )
-        for f in fields
-    )
+def _render_case_body(entries):
+    """Renders the body of a single switch arm.
+
+    Each entry is `(field, has_residual)` where `has_residual` indicates
+    whether the field's existence condition has predicate conjuncts beyond
+    the discriminant equality. When there is no residual the case body is
+    a single direct Ok() check; when there is a residual the body falls
+    back to the has_${field}() accessor, which encapsulates the full
+    existence check including the residual conjuncts. The C++ compiler is
+    then trusted to fold the now-trivially-true discriminant comparison
+    inside the has_${field}() call (it's inlined and the case label has
+    pinned the discriminant value).
+    """
+    parts = []
+    for field, has_residual in entries:
+        name = _cpp_field_name(field.name.name.text)
+        if has_residual:
+            parts.append(
+                "          if (!has_{0}().Known()) return false;\n".format(name)
+            )
+            parts.append(
+                "          if (has_{0}().ValueOrDefault() && !{0}().Ok()) return false;\n".format(
+                    name
+                )
+            )
+        else:
+            parts.append("          if (!{}().Ok()) return false;\n".format(name))
+    return "".join(parts)
 
 
 def _emit_switch_block(group):
@@ -1551,7 +1735,7 @@ def _emit_switch_block(group):
     body_to_labels = {}
     body_first_seen = {}
     for case_str, case_entry in group["cases_by_label"].items():
-        body = _render_case_body(case_entry["fields"])
+        body = _render_case_body(case_entry["entries"])
         body_to_labels.setdefault(body, []).append((case_entry["sort_key"], case_str))
         if body not in body_first_seen:
             body_first_seen[body] = case_entry["sort_key"]

--- a/compiler/back_end/cpp/testcode/many_conditionals_benchmark.cc
+++ b/compiler/back_end/cpp/testcode/many_conditionals_benchmark.cc
@@ -47,6 +47,30 @@ TEST(ComplexConditionals, DuplicateCaseValueFallthrough) {
   EXPECT_FALSE(view.Ok());
 }
 
+TEST(DisjunctionConditionals, OkAcrossTagSpace) {
+  // Exercises the disjunction-of-equality matching path: each conditional
+  // field is guarded by an `||` chain over the same discriminant, so the
+  // generator should produce one multi-label switch arm per group rather
+  // than a chain of redundant per-disjunct if-statements.
+  std::vector<char> buffer(8, 0);
+  auto view = emboss::test::MakeDisjunctionConditionalsView(&buffer);
+  auto start = std::chrono::high_resolution_clock::now();
+  int iterations = 10000;
+  volatile bool result = false;
+  for (int i = 0; i < iterations; ++i) {
+    for (int tag : {0, 1, 2, 10, 11, 100, 200, 300, 7, 50, 999}) {
+      view.tag().Write(tag);
+      result = view.Ok();
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = end - start;
+  std::cout << "DisjunctionConditionals: " << iterations
+            << " iterations (x11 tags): " << elapsed.count() << "s"
+            << std::endl;
+  EXPECT_TRUE(result);
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace emboss

--- a/testdata/golden_cpp/condition.emb.h
+++ b/testdata/golden_cpp/condition.emb.h
@@ -258,14 +258,6 @@ class GenericBasicConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -282,19 +274,8 @@ class GenericBasicConditionalView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -1357,14 +1338,6 @@ class GenericConditionalAndUnconditionalOverlappingFinalFieldView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -1384,19 +1357,8 @@ class GenericConditionalAndUnconditionalOverlappingFinalFieldView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -1953,14 +1915,6 @@ class GenericConditionalBasicConditionalFieldFirstView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -1977,19 +1931,8 @@ class GenericConditionalBasicConditionalFieldFirstView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -2466,14 +2409,6 @@ class GenericConditionalAndDynamicLocationView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -2493,19 +2428,8 @@ class GenericConditionalAndDynamicLocationView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -3117,20 +3041,6 @@ class GenericConditionUsesMinIntView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-    const auto emboss_reserved_local_ok_subexpr_3 =
-        ::emboss::support::Difference</**/ ::std::int64_t, ::std::int64_t,
-                                      ::std::int32_t, ::std::int64_t>(
-            emboss_reserved_local_ok_subexpr_2,
-            ::emboss::support::Maybe</**/ ::std::int64_t>(
-                static_cast</**/ ::std::int64_t>(9223372036854775680LL)));
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -3147,19 +3057,8 @@ class GenericConditionUsesMinIntView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_3;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int64_t>(-9223372036854775807LL - 1):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -3683,21 +3582,6 @@ class GenericNestedConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-    const auto emboss_reserved_local_ok_subexpr_3 = xc();
-    const auto emboss_reserved_local_ok_subexpr_4 =
-        (emboss_reserved_local_ok_subexpr_3.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_3.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -3714,33 +3598,11 @@ class GenericNestedConditionalView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
-        default:
-          break;
-      }
-    }
-
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_4;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xcc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xcc().Known()) return false;
+    if (has_xcc().ValueOrDefault() && !xcc().Ok()) return false;
 
     return true;
   }
@@ -4389,15 +4251,14 @@ class GenericCorrectNestedConditionalView final {
       switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
         case static_cast</**/ ::std::int32_t>(0LL):
           if (!xc().Ok()) return false;
+          if (!has_xcc().Known()) return false;
+          if (has_xcc().ValueOrDefault() && !xcc().Ok()) return false;
           break;
 
         default:
           break;
       }
     }
-
-    if (!has_xcc().Known()) return false;
-    if (has_xcc().ValueOrDefault() && !xcc().Ok()) return false;
 
     return true;
   }
@@ -6860,14 +6721,6 @@ class GenericConditionDoesNotContributeToSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -6887,19 +6740,8 @@ class GenericConditionDoesNotContributeToSizeView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }
@@ -7532,14 +7374,6 @@ class GenericEnumConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::emboss::test::OnOff>(
-                   static_cast</**/ ::emboss::test::OnOff>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::emboss::test::OnOff>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -7556,19 +7390,8 @@ class GenericEnumConditionView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::emboss::test::OnOff>(1):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     if (!has_xc2().Known()) return false;
     if (has_xc2().ValueOrDefault() && !xc2().Ok()) return false;
@@ -13514,43 +13337,6 @@ class GenericChoiceConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = field();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe<
-                   /**/ ::emboss::test::ChoiceCondition::Field>(
-                   static_cast</**/ ::emboss::test::ChoiceCondition::Field>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe<
-                   /**/ ::emboss::test::ChoiceCondition::Field>());
-    const auto emboss_reserved_local_ok_subexpr_3 = ::emboss::support::Equal<
-        /**/ ::emboss::test::ChoiceCondition::Field, bool,
-        ::emboss::test::ChoiceCondition::Field,
-        ::emboss::test::ChoiceCondition::Field>(
-        emboss_reserved_local_ok_subexpr_2,
-        ::emboss::support::Maybe</**/ ::emboss::test::ChoiceCondition::Field>(
-            static_cast</**/ ::emboss::test::ChoiceCondition::Field>(1)));
-    const auto emboss_reserved_local_ok_subexpr_4 = x();
-    const auto emboss_reserved_local_ok_subexpr_5 =
-        (emboss_reserved_local_ok_subexpr_4.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_4.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-    const auto emboss_reserved_local_ok_subexpr_6 = y();
-    const auto emboss_reserved_local_ok_subexpr_7 =
-        (emboss_reserved_local_ok_subexpr_6.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_6.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-    const auto emboss_reserved_local_ok_subexpr_8 =
-        ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
-                                  ::std::int32_t, ::std::int32_t>(
-            emboss_reserved_local_ok_subexpr_3,
-            emboss_reserved_local_ok_subexpr_5,
-            emboss_reserved_local_ok_subexpr_7);
-
     if (!has_field().Known()) return false;
     if (has_field().ValueOrDefault() && !field().Ok()) return false;
 
@@ -13573,19 +13359,8 @@ class GenericChoiceConditionView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_8;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(5LL):
-          if (!xyc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xyc().Known()) return false;
+    if (has_xyc().ValueOrDefault() && !xyc().Ok()) return false;
 
     return true;
   }
@@ -15250,14 +15025,6 @@ class GenericContainsContainsBitsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = condition().has_top();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_condition().Known()) return false;
     if (has_condition().ValueOrDefault() && !condition().Ok()) return false;
 
@@ -15274,19 +15041,8 @@ class GenericContainsContainsBitsView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(1LL):
-          if (!top().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_top().Known()) return false;
+    if (has_top().ValueOrDefault() && !top().Ok()) return false;
 
     return true;
   }
@@ -17563,14 +17319,6 @@ class GenericEmbossReservedAnonymousField2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = low();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_low().Known()) return false;
     if (has_low().ValueOrDefault() && !low().Ok()) return false;
 
@@ -17590,19 +17338,8 @@ class GenericEmbossReservedAnonymousField2View final {
     if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(1LL):
-          if (!mid().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_mid().Known()) return false;
+    if (has_mid().ValueOrDefault() && !mid().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/many_conditionals.emb.h
+++ b/testdata/golden_cpp/many_conditionals.emb.h
@@ -23,6 +23,11 @@ namespace LargeConditionals {}  // namespace LargeConditionals
 template <class Storage>
 class GenericLargeConditionalsView;
 
+namespace DisjunctionConditionals {}  // namespace DisjunctionConditionals
+
+template <class Storage>
+class GenericDisjunctionConditionalsView;
+
 namespace LargeConditionals {}  // namespace LargeConditionals
 
 template <class View>
@@ -10043,6 +10048,805 @@ MakeAlignedLargeConditionalsView(T* emboss_reserved_local_data,
       emboss_reserved_local_data, emboss_reserved_local_size);
 }
 
+namespace DisjunctionConditionals {}  // namespace DisjunctionConditionals
+
+template <class View>
+struct EmbossReservedInternalIsGenericDisjunctionConditionalsView;
+
+template <class Storage>
+class GenericDisjunctionConditionalsView final {
+ public:
+  GenericDisjunctionConditionalsView() : backing_() {}
+  explicit GenericDisjunctionConditionalsView(
+      Storage emboss_reserved_local_bytes)
+      : backing_(emboss_reserved_local_bytes) {}
+
+  template <typename OtherStorage>
+  GenericDisjunctionConditionalsView(
+      const GenericDisjunctionConditionalsView<OtherStorage>&
+          emboss_reserved_local_other)
+      : backing_{emboss_reserved_local_other.BackingStorage()} {}
+
+  template <typename Arg,
+            typename = typename ::std::enable_if<
+                !EmbossReservedInternalIsGenericDisjunctionConditionalsView<
+                    typename ::std::remove_cv<typename ::std::remove_reference<
+                        Arg>::type>::type>::value>::type>
+  explicit GenericDisjunctionConditionalsView(Arg&& emboss_reserved_local_arg)
+      : backing_(::std::forward<Arg>(emboss_reserved_local_arg)) {}
+  template <typename Arg0, typename Arg1, typename... Args>
+  explicit GenericDisjunctionConditionalsView(
+      Arg0&& emboss_reserved_local_arg0, Arg1&& emboss_reserved_local_arg1,
+      Args&&... emboss_reserved_local_args)
+      : backing_(::std::forward<Arg0>(emboss_reserved_local_arg0),
+                 ::std::forward<Arg1>(emboss_reserved_local_arg1),
+                 ::std::forward<Args>(emboss_reserved_local_args)...) {}
+
+  template <typename OtherStorage>
+  GenericDisjunctionConditionalsView<Storage>& operator=(
+      const GenericDisjunctionConditionalsView<OtherStorage>&
+          emboss_reserved_local_other) {
+    backing_ = emboss_reserved_local_other.BackingStorage();
+    return *this;
+  }
+
+  bool Ok() const {
+    if (!IsComplete()) return false;
+
+    const auto emboss_reserved_local_ok_subexpr_1 = tag();
+    const auto emboss_reserved_local_ok_subexpr_2 =
+        (emboss_reserved_local_ok_subexpr_1.Ok()
+             ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                   static_cast</**/ ::std::uint32_t>(
+                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
+             : ::emboss::support::Maybe</**/ ::std::uint32_t>());
+
+    if (!has_tag().Known()) return false;
+    if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
+
+    if (!has_IntrinsicSizeInBytes().Known()) return false;
+    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
+        !IntrinsicSizeInBytes().Ok())
+      return false;
+
+    if (!has_MaxSizeInBytes().Known()) return false;
+    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
+      return false;
+
+    if (!has_MinSizeInBytes().Known()) return false;
+    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
+      return false;
+
+    {
+      const auto emboss_reserved_switch_discrim =
+          emboss_reserved_local_ok_subexpr_2;
+      if (!emboss_reserved_switch_discrim.Known()) return false;
+      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
+        case static_cast</**/ ::std::int32_t>(0LL):
+        case static_cast</**/ ::std::int32_t>(1LL):
+        case static_cast</**/ ::std::int32_t>(2LL):
+          if (!shared_low().Ok()) return false;
+          break;
+
+        case static_cast</**/ ::std::int32_t>(10LL):
+        case static_cast</**/ ::std::int32_t>(11LL):
+          if (!shared_high().Ok()) return false;
+          break;
+
+        case static_cast</**/ ::std::int32_t>(100LL):
+        case static_cast</**/ ::std::int32_t>(200LL):
+        case static_cast</**/ ::std::int32_t>(300LL):
+          if (!shared_far().Ok()) return false;
+          break;
+
+        default:
+          break;
+      }
+    }
+
+    return true;
+  }
+  Storage BackingStorage() const { return backing_; }
+  bool IsComplete() const {
+    return backing_.Ok() && IntrinsicSizeInBytes().Ok() &&
+           backing_.SizeInBytes() >=
+               static_cast</**/ ::std::size_t>(
+                   IntrinsicSizeInBytes().UncheckedRead());
+  }
+  ::std::size_t SizeInBytes() const {
+    return static_cast</**/ ::std::size_t>(IntrinsicSizeInBytes().Read());
+  }
+  bool SizeIsKnown() const { return IntrinsicSizeInBytes().Ok(); }
+
+  template <typename OtherStorage>
+  bool Equals(GenericDisjunctionConditionalsView<OtherStorage>
+                  emboss_reserved_local_other) const {
+    if (!has_tag().Known()) return false;
+    if (!emboss_reserved_local_other.has_tag().Known()) return false;
+
+    if (emboss_reserved_local_other.has_tag().ValueOrDefault() &&
+        !has_tag().ValueOrDefault())
+      return false;
+    if (has_tag().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_tag().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_tag().ValueOrDefault() &&
+        has_tag().ValueOrDefault() &&
+        !tag().Equals(emboss_reserved_local_other.tag()))
+      return false;
+
+    if (!has_shared_low().Known()) return false;
+    if (!emboss_reserved_local_other.has_shared_low().Known()) return false;
+
+    if (emboss_reserved_local_other.has_shared_low().ValueOrDefault() &&
+        !has_shared_low().ValueOrDefault())
+      return false;
+    if (has_shared_low().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_shared_low().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_low().ValueOrDefault() &&
+        has_shared_low().ValueOrDefault() &&
+        !shared_low().Equals(emboss_reserved_local_other.shared_low()))
+      return false;
+
+    if (!has_shared_high().Known()) return false;
+    if (!emboss_reserved_local_other.has_shared_high().Known()) return false;
+
+    if (emboss_reserved_local_other.has_shared_high().ValueOrDefault() &&
+        !has_shared_high().ValueOrDefault())
+      return false;
+    if (has_shared_high().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_shared_high().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_high().ValueOrDefault() &&
+        has_shared_high().ValueOrDefault() &&
+        !shared_high().Equals(emboss_reserved_local_other.shared_high()))
+      return false;
+
+    if (!has_shared_far().Known()) return false;
+    if (!emboss_reserved_local_other.has_shared_far().Known()) return false;
+
+    if (emboss_reserved_local_other.has_shared_far().ValueOrDefault() &&
+        !has_shared_far().ValueOrDefault())
+      return false;
+    if (has_shared_far().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_shared_far().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_far().ValueOrDefault() &&
+        has_shared_far().ValueOrDefault() &&
+        !shared_far().Equals(emboss_reserved_local_other.shared_far()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  bool UncheckedEquals(GenericDisjunctionConditionalsView<OtherStorage>
+                           emboss_reserved_local_other) const {
+    if (emboss_reserved_local_other.has_tag().ValueOr(false) &&
+        !has_tag().ValueOr(false))
+      return false;
+    if (has_tag().ValueOr(false) &&
+        !emboss_reserved_local_other.has_tag().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_tag().ValueOr(false) &&
+        has_tag().ValueOr(false) &&
+        !tag().UncheckedEquals(emboss_reserved_local_other.tag()))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_low().ValueOr(false) &&
+        !has_shared_low().ValueOr(false))
+      return false;
+    if (has_shared_low().ValueOr(false) &&
+        !emboss_reserved_local_other.has_shared_low().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_low().ValueOr(false) &&
+        has_shared_low().ValueOr(false) &&
+        !shared_low().UncheckedEquals(emboss_reserved_local_other.shared_low()))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_high().ValueOr(false) &&
+        !has_shared_high().ValueOr(false))
+      return false;
+    if (has_shared_high().ValueOr(false) &&
+        !emboss_reserved_local_other.has_shared_high().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_high().ValueOr(false) &&
+        has_shared_high().ValueOr(false) &&
+        !shared_high().UncheckedEquals(
+            emboss_reserved_local_other.shared_high()))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_far().ValueOr(false) &&
+        !has_shared_far().ValueOr(false))
+      return false;
+    if (has_shared_far().ValueOr(false) &&
+        !emboss_reserved_local_other.has_shared_far().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_shared_far().ValueOr(false) &&
+        has_shared_far().ValueOr(false) &&
+        !shared_far().UncheckedEquals(emboss_reserved_local_other.shared_far()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  void UncheckedCopyFrom(GenericDisjunctionConditionalsView<OtherStorage>
+                             emboss_reserved_local_other) const {
+    backing_.UncheckedCopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().UncheckedRead());
+  }
+
+  template <typename OtherStorage>
+  void CopyFrom(GenericDisjunctionConditionalsView<OtherStorage>
+                    emboss_reserved_local_other) const {
+    backing_.CopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+  template <typename OtherStorage>
+  bool TryToCopyFrom(GenericDisjunctionConditionalsView<OtherStorage>
+                         emboss_reserved_local_other) const {
+    return emboss_reserved_local_other.Ok() &&
+           backing_.TryToCopyFrom(
+               emboss_reserved_local_other.BackingStorage(),
+               emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+
+  template <class Stream>
+  bool UpdateFromTextStream(Stream* emboss_reserved_local_stream) const {
+    ::std::string emboss_reserved_local_brace;
+    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                      &emboss_reserved_local_brace))
+      return false;
+    if (emboss_reserved_local_brace != "{") return false;
+    for (;;) {
+      ::std::string emboss_reserved_local_name;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_name))
+        return false;
+      if (emboss_reserved_local_name == ",")
+        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                          &emboss_reserved_local_name))
+          return false;
+      if (emboss_reserved_local_name == "}") return true;
+      ::std::string emboss_reserved_local_colon;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_colon))
+        return false;
+      if (emboss_reserved_local_colon != ":") return false;
+      if (emboss_reserved_local_name == "tag") {
+        if (!tag().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (emboss_reserved_local_name == "shared_low") {
+        if (!shared_low().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (emboss_reserved_local_name == "shared_high") {
+        if (!shared_high().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (emboss_reserved_local_name == "shared_far") {
+        if (!shared_far().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  template <class Stream>
+  void WriteToTextStream(
+      Stream* emboss_reserved_local_stream,
+      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
+    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
+        emboss_reserved_local_options.PlusOneIndent();
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write("{\n");
+    } else {
+      emboss_reserved_local_stream->Write("{");
+    }
+    bool emboss_reserved_local_wrote_field = false;
+    if (has_tag().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          tag().IsAggregate() || tag().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("tag: ");
+        tag().WriteToTextStream(emboss_reserved_local_stream,
+                                emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !tag().IsAggregate() && !tag().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# tag: UNREADABLE\n");
+      }
+    }
+
+    if (has_shared_low().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          shared_low().IsAggregate() || shared_low().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("shared_low: ");
+        shared_low().WriteToTextStream(emboss_reserved_local_stream,
+                                       emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !shared_low().IsAggregate() && !shared_low().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# shared_low: UNREADABLE\n");
+      }
+    }
+
+    if (has_shared_high().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          shared_high().IsAggregate() || shared_high().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("shared_high: ");
+        shared_high().WriteToTextStream(emboss_reserved_local_stream,
+                                        emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !shared_high().IsAggregate() && !shared_high().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# shared_high: UNREADABLE\n");
+      }
+    }
+
+    if (has_shared_far().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          shared_far().IsAggregate() || shared_far().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("shared_far: ");
+        shared_far().WriteToTextStream(emboss_reserved_local_stream,
+                                       emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !shared_far().IsAggregate() && !shared_far().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# shared_far: UNREADABLE\n");
+      }
+    }
+
+    (void)emboss_reserved_local_wrote_field;
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write(
+          emboss_reserved_local_options.current_indent());
+      emboss_reserved_local_stream->Write("}");
+    } else {
+      emboss_reserved_local_stream->Write(" }");
+    }
+  }
+
+  static constexpr bool IsAggregate() { return true; }
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          32>>
+
+  tag() const;
+  ::emboss::support::Maybe<bool> has_tag() const;
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+  shared_low() const;
+  ::emboss::support::Maybe<bool> has_shared_low() const;
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+  shared_high() const;
+  ::emboss::support::Maybe<bool> has_shared_high() const;
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+  shared_far() const;
+  ::emboss::support::Maybe<bool> has_shared_far() const;
+
+ public:
+  class EmbossReservedDollarVirtualIntrinsicSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    explicit EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const GenericDisjunctionConditionalsView& emboss_reserved_local_view)
+        : view_(emboss_reserved_local_view) {}
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = delete;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = default;
+
+    ::std::int32_t Read() const {
+      EMBOSS_CHECK(view_.has_IntrinsicSizeInBytes().ValueOr(false));
+      auto emboss_reserved_local_value = MaybeRead();
+      EMBOSS_CHECK(emboss_reserved_local_value.Known());
+      EMBOSS_CHECK(ValueIsOk(emboss_reserved_local_value.ValueOrDefault()));
+      return emboss_reserved_local_value.ValueOrDefault();
+    }
+    ::std::int32_t UncheckedRead() const {
+      return MaybeRead().ValueOrDefault();
+    }
+    bool Ok() const {
+      auto emboss_reserved_local_value = MaybeRead();
+      return emboss_reserved_local_value.Known() &&
+             ValueIsOk(emboss_reserved_local_value.ValueOrDefault());
+    }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+
+   private:
+    ::emboss::support::Maybe</**/ ::std::int32_t> MaybeRead() const {
+      const auto emboss_reserved_local_subexpr_1 = view_.tag();
+      const auto emboss_reserved_local_subexpr_2 =
+          (emboss_reserved_local_subexpr_1.Ok()
+               ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                     static_cast</**/ ::std::uint32_t>(
+                         emboss_reserved_local_subexpr_1.UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::uint32_t>());
+      const auto emboss_reserved_local_subexpr_3 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_4 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(1LL)));
+      const auto emboss_reserved_local_subexpr_5 =
+          ::emboss::support::Or</**/ bool, bool, bool, bool>(
+              emboss_reserved_local_subexpr_3, emboss_reserved_local_subexpr_4);
+      const auto emboss_reserved_local_subexpr_6 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(2LL)));
+      const auto emboss_reserved_local_subexpr_7 =
+          ::emboss::support::Or</**/ bool, bool, bool, bool>(
+              emboss_reserved_local_subexpr_5, emboss_reserved_local_subexpr_6);
+      const auto emboss_reserved_local_subexpr_8 =
+          ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
+                                    ::std::int32_t, ::std::int32_t>(
+              emboss_reserved_local_subexpr_7,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(8LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_9 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(10LL)));
+      const auto emboss_reserved_local_subexpr_10 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(11LL)));
+      const auto emboss_reserved_local_subexpr_11 =
+          ::emboss::support::Or</**/ bool, bool, bool, bool>(
+              emboss_reserved_local_subexpr_9,
+              emboss_reserved_local_subexpr_10);
+      const auto emboss_reserved_local_subexpr_12 =
+          ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
+                                    ::std::int32_t, ::std::int32_t>(
+              emboss_reserved_local_subexpr_11,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(8LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_13 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(100LL)));
+      const auto emboss_reserved_local_subexpr_14 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(200LL)));
+      const auto emboss_reserved_local_subexpr_15 =
+          ::emboss::support::Or</**/ bool, bool, bool, bool>(
+              emboss_reserved_local_subexpr_13,
+              emboss_reserved_local_subexpr_14);
+      const auto emboss_reserved_local_subexpr_16 =
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_2,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(300LL)));
+      const auto emboss_reserved_local_subexpr_17 =
+          ::emboss::support::Or</**/ bool, bool, bool, bool>(
+              emboss_reserved_local_subexpr_15,
+              emboss_reserved_local_subexpr_16);
+      const auto emboss_reserved_local_subexpr_18 =
+          ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
+                                    ::std::int32_t, ::std::int32_t>(
+              emboss_reserved_local_subexpr_17,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(8LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_19 = ::emboss::support::Maximum<
+          /**/ ::std::int32_t, ::std::int32_t, ::std::int32_t, ::std::int32_t,
+          ::std::int32_t, ::std::int32_t, ::std::int32_t>(
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(0LL)),
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(4LL)),
+          emboss_reserved_local_subexpr_8, emboss_reserved_local_subexpr_12,
+          emboss_reserved_local_subexpr_18);
+
+      return emboss_reserved_local_subexpr_19;
+    }
+
+    static constexpr bool ValueIsOk(
+        ::std::int32_t emboss_reserved_local_value) {
+      return (void)emboss_reserved_local_value,  // Silence -Wunused-parameter
+             ::emboss::support::Maybe<bool>(true).ValueOr(false);
+    }
+
+    const GenericDisjunctionConditionalsView view_;
+  };
+  EmbossReservedDollarVirtualIntrinsicSizeInBytesView IntrinsicSizeInBytes()
+      const;
+  ::emboss::support::Maybe<bool> has_IntrinsicSizeInBytes() const;
+
+ public:
+  class EmbossReservedDollarVirtualMaxSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMaxSizeInBytesView() {}
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMaxSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMaxSizeInBytesView
+  MaxSizeInBytes() {
+    return EmbossReservedDollarVirtualMaxSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MaxSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ public:
+  class EmbossReservedDollarVirtualMinSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMinSizeInBytesView() {}
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMinSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMinSizeInBytesView
+  MinSizeInBytes() {
+    return EmbossReservedDollarVirtualMinSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MinSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ private:
+  Storage backing_;
+
+  template <class OtherStorage>
+  friend class GenericDisjunctionConditionalsView;
+};
+using DisjunctionConditionalsView = GenericDisjunctionConditionalsView<
+    /**/ ::emboss::support::ReadOnlyContiguousBuffer>;
+using DisjunctionConditionalsWriter = GenericDisjunctionConditionalsView<
+    /**/ ::emboss::support::ReadWriteContiguousBuffer>;
+
+template <class View>
+struct EmbossReservedInternalIsGenericDisjunctionConditionalsView {
+  static constexpr const bool value = false;
+};
+
+template <class Storage>
+struct EmbossReservedInternalIsGenericDisjunctionConditionalsView<
+    GenericDisjunctionConditionalsView<Storage>> {
+  static constexpr const bool value = true;
+};
+
+template <typename T>
+inline GenericDisjunctionConditionalsView<
+    /**/ ::emboss::support::ContiguousBuffer<
+        typename ::std::remove_reference<
+            decltype(*::std::declval<T>()->data())>::type,
+        1, 0>>
+MakeDisjunctionConditionalsView(T&& emboss_reserved_local_arg) {
+  return GenericDisjunctionConditionalsView<
+      /**/ ::emboss::support::ContiguousBuffer<
+          typename ::std::remove_reference<
+              decltype(*::std::declval<T>()->data())>::type,
+          1, 0>>(::std::forward<T>(emboss_reserved_local_arg));
+}
+
+template <typename T>
+inline GenericDisjunctionConditionalsView<
+    /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>
+MakeDisjunctionConditionalsView(T* emboss_reserved_local_data,
+                                ::std::size_t emboss_reserved_local_size) {
+  return GenericDisjunctionConditionalsView<
+      /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+template <typename T, ::std::size_t kAlignment>
+inline GenericDisjunctionConditionalsView<
+    /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>
+MakeAlignedDisjunctionConditionalsView(
+    T* emboss_reserved_local_data, ::std::size_t emboss_reserved_local_size) {
+  return GenericDisjunctionConditionalsView<
+      /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
 namespace LargeConditionals {}  // namespace LargeConditionals
 
 template <class Storage>
@@ -16006,6 +16810,331 @@ template <class Storage>
 inline constexpr ::std::int32_t GenericLargeConditionalsView<
     Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
   return LargeConditionals::MinSizeInBytes();
+}
+namespace DisjunctionConditionals {}  // namespace DisjunctionConditionals
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        32, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 0>>,
+        32>>
+
+GenericDisjunctionConditionalsView<Storage>::tag() const {
+  if (has_tag().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(0LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              32, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 0>>,
+              32>>
+
+          (backing_.template GetOffsetStorage<0, 0>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          32>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericDisjunctionConditionalsView<Storage>::has_tag() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        32, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 4>>,
+        32>>
+
+GenericDisjunctionConditionalsView<Storage>::shared_low() const {
+  if (has_shared_low().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              32, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 4>>,
+              32>>
+
+          (backing_.template GetOffsetStorage<0, 4>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericDisjunctionConditionalsView<Storage>::has_shared_low() const {
+  return ::emboss::support::Or</**/ bool, bool, bool, bool>(
+      ::emboss::support::Or</**/ bool, bool, bool, bool>(
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              (tag().Ok() ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                                static_cast</**/ ::std::uint32_t>(
+                                    tag().UncheckedRead()))
+                          : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL))),
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              (tag().Ok() ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                                static_cast</**/ ::std::uint32_t>(
+                                    tag().UncheckedRead()))
+                          : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(1LL)))),
+      ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                               ::std::int32_t>(
+          (tag().Ok()
+               ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                     static_cast</**/ ::std::uint32_t>(tag().UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(2LL))));
+}
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        32, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 4>>,
+        32>>
+
+GenericDisjunctionConditionalsView<Storage>::shared_high() const {
+  if (has_shared_high().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              32, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 4>>,
+              32>>
+
+          (backing_.template GetOffsetStorage<0, 4>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericDisjunctionConditionalsView<Storage>::has_shared_high() const {
+  return ::emboss::support::Or</**/ bool, bool, bool, bool>(
+      ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                               ::std::int32_t>(
+          (tag().Ok()
+               ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                     static_cast</**/ ::std::uint32_t>(tag().UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(10LL))),
+      ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                               ::std::int32_t>(
+          (tag().Ok()
+               ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                     static_cast</**/ ::std::uint32_t>(tag().UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(11LL))));
+}
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        32, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 4>>,
+        32>>
+
+GenericDisjunctionConditionalsView<Storage>::shared_far() const {
+  if (has_shared_far().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(4LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              32, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 4>>,
+              32>>
+
+          (backing_.template GetOffsetStorage<0, 4>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          32, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 4>>,
+          32>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericDisjunctionConditionalsView<Storage>::has_shared_far() const {
+  return ::emboss::support::Or</**/ bool, bool, bool, bool>(
+      ::emboss::support::Or</**/ bool, bool, bool, bool>(
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              (tag().Ok() ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                                static_cast</**/ ::std::uint32_t>(
+                                    tag().UncheckedRead()))
+                          : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(100LL))),
+          ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                                   ::std::int32_t>(
+              (tag().Ok() ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                                static_cast</**/ ::std::uint32_t>(
+                                    tag().UncheckedRead()))
+                          : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(200LL)))),
+      ::emboss::support::Equal</**/ ::std::uint32_t, bool, ::std::uint32_t,
+                               ::std::int32_t>(
+          (tag().Ok()
+               ? ::emboss::support::Maybe</**/ ::std::uint32_t>(
+                     static_cast</**/ ::std::uint32_t>(tag().UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::uint32_t>()),
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(300LL))));
+}
+
+template <class Storage>
+inline typename GenericDisjunctionConditionalsView<
+    Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView
+GenericDisjunctionConditionalsView<Storage>::IntrinsicSizeInBytes() const {
+  return typename GenericDisjunctionConditionalsView<
+      Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView(*this);
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericDisjunctionConditionalsView<Storage>::has_IntrinsicSizeInBytes() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+namespace DisjunctionConditionals {
+inline constexpr ::std::int32_t MaxSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(8LL))
+      .ValueOrDefault();
+}
+}  // namespace DisjunctionConditionals
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericDisjunctionConditionalsView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::Read() {
+  return DisjunctionConditionals::MaxSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericDisjunctionConditionalsView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::UncheckedRead() {
+  return DisjunctionConditionals::MaxSizeInBytes();
+}
+
+namespace DisjunctionConditionals {
+inline constexpr ::std::int32_t MinSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(4LL))
+      .ValueOrDefault();
+}
+}  // namespace DisjunctionConditionals
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericDisjunctionConditionalsView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::Read() {
+  return DisjunctionConditionals::MinSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericDisjunctionConditionalsView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
+  return DisjunctionConditionals::MinSizeInBytes();
 }
 
 }  // namespace test

--- a/testdata/golden_cpp/virtual_field.emb.h
+++ b/testdata/golden_cpp/virtual_field.emb.h
@@ -9662,14 +9662,6 @@ class GenericVirtualUnconditionallyUsesConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    const auto emboss_reserved_local_ok_subexpr_1 = x();
-    const auto emboss_reserved_local_ok_subexpr_2 =
-        (emboss_reserved_local_ok_subexpr_1.Ok()
-             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
-                   static_cast</**/ ::std::int32_t>(
-                       emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
-             : ::emboss::support::Maybe</**/ ::std::int32_t>());
-
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
 
@@ -9689,19 +9681,8 @@ class GenericVirtualUnconditionallyUsesConditionalView final {
     if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
       return false;
 
-    {
-      const auto emboss_reserved_switch_discrim =
-          emboss_reserved_local_ok_subexpr_2;
-      if (!emboss_reserved_switch_discrim.Known()) return false;
-      switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-        case static_cast</**/ ::std::int32_t>(0LL):
-          if (!xc().Ok()) return false;
-          break;
-
-        default:
-          break;
-      }
-    }
+    if (!has_xc().Known()) return false;
+    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
 
     return true;
   }

--- a/testdata/many_conditionals.emb
+++ b/testdata/many_conditionals.emb
@@ -306,3 +306,16 @@ struct LargeConditionals:
 
   if tag == 0:
     8 [+4]  UInt  f0_copy
+
+
+# Exercises disjunction-of-equality matching: each conditional field is
+# guarded by an `||` of multiple discriminant values, which collapses into a
+# single multi-label switch arm under the optimized Ok() generator.
+struct DisjunctionConditionals:
+  0 [+4]                                       UInt  tag
+  if tag == 0 || tag == 1 || tag == 2:
+    4 [+4]                                     UInt  shared_low
+  if tag == 10 || tag == 11:
+    4 [+4]                                     UInt  shared_high
+  if tag == 100 || tag == 200 || tag == 300:
+    4 [+4]                                     UInt  shared_far


### PR DESCRIPTION
PR #241's `_get_switch_candidate` only matched bare `discrim == K` equalities. Real protocol grammars express the same intent in many forms; this PR rewrites the matcher to recognize them all.

`_extract_switch_arms` decomposes an `existence_condition` into a `(discriminant, [(case_value, residual), …])` tuple, handling:

  * Bare equality (`tag == K`) — one arm, no residual.
  * Disjunction of equalities on a shared discriminant (`tag == A || tag == B || tag == C`) — one arm per `Ki`, no residual. Common for tagged unions where several values share a payload. Combined with #254's identical-body coalescing, this collapses to a single multi-label switch arm.
  * Conjunction with an equality (`tag == K && other_predicate`) — one arm carrying `[other_predicate]` as residual. Useful for nested guards like `if outer_flag && tag == K`.
  * Mixed shapes inside a disjunction: `(tag == 0 && a) || (tag == 1 && b) || tag == 2` — three arms with respective residuals `[a]`, `[b]`, `[]`.

An arm with a residual emits the `has_${field}()`-based check as its case body (the residual is folded into the existing accessor) — sound and lets the C++ compiler fold the case-pinned discriminant comparison via inlining.

A demotion pass measures total arm-entries per group and falls back to `ok_method_test` when the count is below 2 — without this, a lone field like `if outer && tag == K: xc` would get wrapped in a one-case switch whose overhead (temporary, Known() guard, scope braces) exceeds the dedupe. This also fixes a latent bug from #253: the scoped discriminant render mutated `subexpressions` during the grouping pass, so groups that later got demoted would have left dead `const auto = …;` definitions in the emitted `Ok()`. The scoped render now happens at emit time, only for surviving groups.

The benchmark schema gains a `DisjunctionConditionals` struct exercising three `||` chains (2, 3, 3 labels) and the benchmark TU gains a runtime test for it. Golden churn: `many_conditionals.emb.h` gains the new struct's output; `condition.emb.h` and `virtual_field.emb.h` shrink because several `BasicConditional`-style structs had a lone `xc` field that PR #241 was wrapping in a one-arm switch — demotion brings them back to the cheaper `has_xc()` check.

### Size impact (cumulative vs. master)

| Target | Metric | Master | PR | Delta |
|---|---|---:|---:|---:|
| ARM Thumb-2 | TU .text | 18962 | 18208 | −754 (−4.0%) |
| ARM Thumb-2 | LargeConditionals::Ok() | 5382 | 4746 | −636 (−11.8%) |
| ARM Thumb-2 | DisjunctionConditionals::Ok() | 358 | 270 | **−88 (−24.6%)** |
| MicroBlaze | TU .text | 43640 | 42612 | −1028 (−2.4%) |
| MicroBlaze | LargeConditionals::Ok() | 14824 | 14104 | −720 (−4.9%) |
| MicroBlaze | DisjunctionConditionals::Ok() | 640 | 552 | −88 (−13.8%) |
| Host x86-64 | TU .text | 29166 | 28304 | −862 (−3.0%) |
| Host x86-64 | LargeConditionals::Ok() | 3948 | 3065 | −883 (−22.4%) |
| Host x86-64 | DisjunctionConditionals::Ok() | 431 | 375 | −56 (−13.0%) |

Incremental vs. #254: `DisjunctionConditionals::Ok()` drops 24.6% on Thumb-2, 13.8% on MicroBlaze, 13.0% on x86-64 — the matcher extensions account for nearly all of those.

Stacked on #254.
