### PR TITLE
Statically-known existence conditions: drop or simplify the check

### DIFF
--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -1557,68 +1557,53 @@ def _extract_switch_arms(expression, ir):
 def _generate_optimized_ok_method_body(
     fields, ir, subexpressions, allow_tail_form=False
 ):
-    """Generates optimized C++ code for the Ok() method body.
+    """Generates the field-validation body of a structure's Ok() method.
 
-    This function optimizes validation logic for structures with conditional
-    fields by grouping fields that share the same discriminant into switch
-    statements, rather than generating separate if-statements for each field.
+    For each conditional field, routes it to one of four emit paths:
 
-    For example, given this Emboss definition:
+      1. **Skipped**. `if false:` fields can never be present, so Ok()
+         needs no check for them at all.
+      2. **Unconditional**. Non-conditional and `if true:` fields skip
+         the has_${field}() wrapper and emit a bare
+         `if (!field().Ok()) return false;` — has_X() is statically
+         Known and always true.
+      3. **Switch arm**. Fields whose existence condition decomposes
+         into a discriminant test (`discrim == K`, a disjunction of
+         such tests, or an AND with an equality conjunct) join a
+         switch on the shared discriminant. _extract_switch_arms does
+         the decomposition; the optimizer then sorts cases by value,
+         coalesces arms with identical bodies into multi-label arms,
+         and (for the switch that ends the function) rewrites
+         single-field bare arms as tail-form `return field().Ok();`.
+         A demotion pass falls back to (4) for switch groups whose
+         total entry count is below 2 (the switch wrapper is bigger
+         than the dedupe saves).
+      4. **ok_method_test**. The fallback: the existing
+         has_${field}()-based check. Used for conditions that don't
+         match any of the above and for switch groups demoted by (3).
 
-        struct Foo:
-          0 [+4]  UInt  tag
-          if tag == 0:
-            4 [+4]  UInt  var_0
-          if tag == 1:
-            4 [+4]  UInt  var_1
-          if tag == 0:
-            8 [+4]  UInt  var_x
-
-    Instead of generating separate if-statements:
-
-        if (tag() == 0 && !var_0().Ok()) return false;
-        if (tag() == 1 && !var_1().Ok()) return false;
-        if (tag() == 0 && !var_x().Ok()) return false;
-
-    This generates an optimized switch statement:
-
-        const auto emboss_reserved_switch_discrim = tag();
-        if (!emboss_reserved_switch_discrim.Known()) return false;
-        switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
-          case 0:
-            if (!var_0().Ok()) return false;
-            break;
-          case 1:
-            if (!var_1().Ok()) return false;
-            break;
-        }
-
-    Note: When multiple fields share the same case value (like var_0 and var_x
-    both guarded by tag == 0), only the first field for that case value is
-    checked in the switch. This is because once we've checked var_0 for case 0,
-    we break out of the switch. Fields with duplicate case values will fall
-    through to the if-statement path.
-
-    Fields with non-equality conditions (or conditions that can't be converted
-    to switch cases) are grouped by their rendered condition and emitted as
-    if-statements.
-
-    Additionally, when a condition is statically known to be true (e.g., fields
-    that are always present), the if-block wrapper is omitted entirely and the
-    field checks are emitted directly. This avoids generating unnecessary
-    runtime checks like:
-
-        const auto emboss_reserved_cond = Maybe<bool>(true);
-        if (!emboss_reserved_cond.Known()) return false;  // Always true
-        if (emboss_reserved_cond.ValueOrDefault()) { ... } // Always true
+    Each surviving switch group emits a single `switch` statement
+    sharing one read of the discriminant subexpression across all the
+    fields it guards — the original PR 241 win. The other emit paths
+    are post-PR 241 refinements that further shrink the generated
+    Ok() on tagged-union and mixed-conditional schemas.
 
     Arguments:
         fields: List of field IR nodes to generate Ok() checks for.
         ir: The full IR for looking up references.
-        subexpressions: An ExpressionScope for sharing common subexpressions.
+        subexpressions: An ExpressionScope for sharing common
+            subexpressions across the whole Ok() body.
+        allow_tail_form: When True, the very last surviving switch
+            group is eligible for tail-form arm rewriting (each
+            single-field bare arm becomes `return field().Ok();`
+            instead of `if (!X().Ok()) return false; break;`). The
+            caller passes True only when the switch is the function's
+            tail — i.e., there is no [requires] clause emitted after
+            the field-ok-checks.
 
     Returns:
-        A string containing the C++ code for the optimized Ok() method body.
+        A string containing the C++ code for the optimized Ok() method
+        body.
     """
     groups = {}
     ordered_keys = []
@@ -1630,6 +1615,28 @@ def _generate_optimized_ok_method_body(
     field_group_key = {}
 
     for field in fields:
+        # Fields whose existence condition is statically known take fast
+        # paths bypassing both the switch and ok_method_test machinery:
+        #   * `if false:` — the field is never present, so there's nothing
+        #     to validate. Drop it entirely.
+        #   * `if true:` (and non-conditional fields, which carry the
+        #     boolean-true literal) — has_${field}() is always Known and
+        #     true, so the has_X()-based guard is dead. Emit just the
+        #     direct `if (!${field}().Ok()) return false;` check.
+        # All unconditional fields share one group so they emit
+        # contiguously (at the position of the first such field), which
+        # keeps the C++ compiler's view of the Ok() body tight enough to
+        # consolidate redundant frame setup across the checks.
+        cond = field.existence_condition
+        if cond.type.which_type == "boolean" and cond.type.boolean.has_field("value"):
+            if cond.type.boolean.value:
+                key = "UNCOND"
+                if key not in groups:
+                    groups[key] = {"type": "unconditional", "fields": []}
+                    ordered_keys.append(key)
+                groups[key]["fields"].append(field)
+            # else: existence is statically false — emit nothing.
+            continue
         discrim_expr, arms = _extract_switch_arms(field.existence_condition, ir)
         if discrim_expr:
             # Render the discriminant unscoped to build the grouping key.
@@ -1734,6 +1741,13 @@ def _generate_optimized_ok_method_body(
                     code_template.format_template(
                         _TEMPLATES.ok_method_test,
                         field=_cpp_field_name(field.name.name.text),
+                    )
+                )
+        elif group["type"] == "unconditional":
+            for field in group["fields"]:
+                blocks.append(
+                    "    if (!{}().Ok()) return false;\n\n".format(
+                        _cpp_field_name(field.name.name.text)
                     )
                 )
         else:

--- a/testdata/golden_cpp/alignments.emb.h
+++ b/testdata/golden_cpp/alignments.emb.h
@@ -75,66 +75,33 @@ class GenericAlignmentsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_zero_offset().Known()) return false;
-    if (has_zero_offset().ValueOrDefault() && !zero_offset().Ok()) return false;
+    if (!zero_offset().Ok()) return false;
 
-    if (!has_zero_offset_substructure().Known()) return false;
-    if (has_zero_offset_substructure().ValueOrDefault() &&
-        !zero_offset_substructure().Ok())
-      return false;
+    if (!zero_offset_substructure().Ok()) return false;
 
-    if (!has_two_offset_substructure().Known()) return false;
-    if (has_two_offset_substructure().ValueOrDefault() &&
-        !two_offset_substructure().Ok())
-      return false;
+    if (!two_offset_substructure().Ok()) return false;
 
-    if (!has_three_offset().Known()) return false;
-    if (has_three_offset().ValueOrDefault() && !three_offset().Ok())
-      return false;
+    if (!three_offset().Ok()) return false;
 
-    if (!has_four_offset().Known()) return false;
-    if (has_four_offset().ValueOrDefault() && !four_offset().Ok()) return false;
+    if (!four_offset().Ok()) return false;
 
-    if (!has_eleven_offset().Known()) return false;
-    if (has_eleven_offset().ValueOrDefault() && !eleven_offset().Ok())
-      return false;
+    if (!eleven_offset().Ok()) return false;
 
-    if (!has_twelve_offset().Known()) return false;
-    if (has_twelve_offset().ValueOrDefault() && !twelve_offset().Ok())
-      return false;
+    if (!twelve_offset().Ok()) return false;
 
-    if (!has_zero_offset_four_stride_array().Known()) return false;
-    if (has_zero_offset_four_stride_array().ValueOrDefault() &&
-        !zero_offset_four_stride_array().Ok())
-      return false;
+    if (!zero_offset_four_stride_array().Ok()) return false;
 
-    if (!has_zero_offset_six_stride_array().Known()) return false;
-    if (has_zero_offset_six_stride_array().ValueOrDefault() &&
-        !zero_offset_six_stride_array().Ok())
-      return false;
+    if (!zero_offset_six_stride_array().Ok()) return false;
 
-    if (!has_three_offset_four_stride_array().Known()) return false;
-    if (has_three_offset_four_stride_array().ValueOrDefault() &&
-        !three_offset_four_stride_array().Ok())
-      return false;
+    if (!three_offset_four_stride_array().Ok()) return false;
 
-    if (!has_four_offset_six_stride_array().Known()) return false;
-    if (has_four_offset_six_stride_array().ValueOrDefault() &&
-        !four_offset_six_stride_array().Ok())
-      return false;
+    if (!four_offset_six_stride_array().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1335,21 +1302,13 @@ class GenericPlaceholder4View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_dummy().Known()) return false;
-    if (has_dummy().ValueOrDefault() && !dummy().Ok()) return false;
+    if (!dummy().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1738,24 +1697,15 @@ class GenericPlaceholder6View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_zero_offset().Known()) return false;
-    if (has_zero_offset().ValueOrDefault() && !zero_offset().Ok()) return false;
+    if (!zero_offset().Ok()) return false;
 
-    if (!has_two_offset().Known()) return false;
-    if (has_two_offset().ValueOrDefault() && !two_offset().Ok()) return false;
+    if (!two_offset().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/anonymous_bits.emb.h
+++ b/testdata/golden_cpp/anonymous_bits.emb.h
@@ -91,27 +91,17 @@ class GenericEmbossReservedAnonymousField2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_high_bit().Known()) return false;
-    if (has_high_bit().ValueOrDefault() && !high_bit().Ok()) return false;
+    if (!high_bit().Ok()) return false;
 
-    if (!has_bar().Known()) return false;
-    if (has_bar().ValueOrDefault() && !bar().Ok()) return false;
+    if (!bar().Ok()) return false;
 
-    if (!has_first_bit().Known()) return false;
-    if (has_first_bit().ValueOrDefault() && !first_bit().Ok()) return false;
+    if (!first_bit().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -739,24 +729,15 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_bit_23().Known()) return false;
-    if (has_bit_23().ValueOrDefault() && !bit_23().Ok()) return false;
+    if (!bit_23().Ok()) return false;
 
-    if (!has_low_bit().Known()) return false;
-    if (has_low_bit().ValueOrDefault() && !low_bit().Ok()) return false;
+    if (!low_bit().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1216,28 +1197,15 @@ class GenericFooView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_2().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_2().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_2().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_2().Ok()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_high_bit().Known()) return false;
     if (has_high_bit().ValueOrDefault() && !high_bit().Ok()) return false;

--- a/testdata/golden_cpp/auto_array_size.emb.h
+++ b/testdata/golden_cpp/auto_array_size.emb.h
@@ -70,24 +70,15 @@ class GenericElementView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -548,38 +539,21 @@ class GenericAutoSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_array_size().Known()) return false;
-    if (has_array_size().ValueOrDefault() && !array_size().Ok()) return false;
+    if (!array_size().Ok()) return false;
 
-    if (!has_four_byte_array().Known()) return false;
-    if (has_four_byte_array().ValueOrDefault() && !four_byte_array().Ok())
-      return false;
+    if (!four_byte_array().Ok()) return false;
 
-    if (!has_four_struct_array().Known()) return false;
-    if (has_four_struct_array().ValueOrDefault() && !four_struct_array().Ok())
-      return false;
+    if (!four_struct_array().Ok()) return false;
 
-    if (!has_dynamic_byte_array().Known()) return false;
-    if (has_dynamic_byte_array().ValueOrDefault() && !dynamic_byte_array().Ok())
-      return false;
+    if (!dynamic_byte_array().Ok()) return false;
 
-    if (!has_dynamic_struct_array().Known()) return false;
-    if (has_dynamic_struct_array().ValueOrDefault() &&
-        !dynamic_struct_array().Ok())
-      return false;
+    if (!dynamic_struct_array().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/bcd.emb.h
+++ b/testdata/golden_cpp/bcd.emb.h
@@ -87,30 +87,19 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_four_bit().Known()) return false;
-    if (has_four_bit().ValueOrDefault() && !four_bit().Ok()) return false;
+    if (!four_bit().Ok()) return false;
 
-    if (!has_six_bit().Known()) return false;
-    if (has_six_bit().ValueOrDefault() && !six_bit().Ok()) return false;
+    if (!six_bit().Ok()) return false;
 
-    if (!has_ten_bit().Known()) return false;
-    if (has_ten_bit().ValueOrDefault() && !ten_bit().Ok()) return false;
+    if (!ten_bit().Ok()) return false;
 
-    if (!has_twelve_bit().Known()) return false;
-    if (has_twelve_bit().ValueOrDefault() && !twelve_bit().Ok()) return false;
+    if (!twelve_bit().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -714,47 +703,29 @@ class GenericBcdSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_four_bit().Known()) return false;
     if (has_four_bit().ValueOrDefault() && !four_bit().Ok()) return false;
@@ -1920,21 +1891,13 @@ class GenericBcdBigEndianView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/bits.emb.h
+++ b/testdata/golden_cpp/bits.emb.h
@@ -96,35 +96,21 @@ class GenericOneByteView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_high_bit().Known()) return false;
-    if (has_high_bit().ValueOrDefault() && !high_bit().Ok()) return false;
+    if (!high_bit().Ok()) return false;
 
-    if (!has_less_high_bit().Known()) return false;
-    if (has_less_high_bit().ValueOrDefault() && !less_high_bit().Ok())
-      return false;
+    if (!less_high_bit().Ok()) return false;
 
-    if (!has_mid_nibble().Known()) return false;
-    if (has_mid_nibble().ValueOrDefault() && !mid_nibble().Ok()) return false;
+    if (!mid_nibble().Ok()) return false;
 
-    if (!has_less_low_bit().Known()) return false;
-    if (has_less_low_bit().ValueOrDefault() && !less_low_bit().Ok())
-      return false;
+    if (!less_low_bit().Ok()) return false;
 
-    if (!has_low_bit().Known()) return false;
-    if (has_low_bit().ValueOrDefault() && !low_bit().Ok()) return false;
+    if (!low_bit().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -827,27 +813,17 @@ class GenericTwoByteWithGapsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_high_bit().Known()) return false;
-    if (has_high_bit().ValueOrDefault() && !high_bit().Ok()) return false;
+    if (!high_bit().Ok()) return false;
 
-    if (!has_mid_nibble().Known()) return false;
-    if (has_mid_nibble().ValueOrDefault() && !mid_nibble().Ok()) return false;
+    if (!mid_nibble().Ok()) return false;
 
-    if (!has_low_bit().Known()) return false;
-    if (has_low_bit().ValueOrDefault() && !low_bit().Ok()) return false;
+    if (!low_bit().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1376,34 +1352,21 @@ class GenericFourByteView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_high_nibble().Known()) return false;
-    if (has_high_nibble().ValueOrDefault() && !high_nibble().Ok()) return false;
+    if (!high_nibble().Ok()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_raw_low_nibble().Known()) return false;
-    if (has_raw_low_nibble().ValueOrDefault() && !raw_low_nibble().Ok())
-      return false;
+    if (!raw_low_nibble().Ok()) return false;
 
-    if (!has_low_nibble().Known()) return false;
-    if (has_low_nibble().ValueOrDefault() && !low_nibble().Ok()) return false;
+    if (!low_nibble().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -2162,24 +2125,15 @@ class GenericArrayInBitsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_lone_flag().Known()) return false;
-    if (has_lone_flag().ValueOrDefault() && !lone_flag().Ok()) return false;
+    if (!lone_flag().Ok()) return false;
 
-    if (!has_flags().Known()) return false;
-    if (has_flags().ValueOrDefault() && !flags().Ok()) return false;
+    if (!flags().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -2641,22 +2595,13 @@ class GenericArrayInBitsInStructView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_array_in_bits().Known()) return false;
-    if (has_array_in_bits().ValueOrDefault() && !array_in_bits().Ok())
-      return false;
+    if (!array_in_bits().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -3045,31 +2990,19 @@ class GenericStructOfBitsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_located_byte().Known()) return false;
-    if (has_located_byte().ValueOrDefault() && !located_byte().Ok())
-      return false;
+    if (!located_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -3738,21 +3671,13 @@ class GenericBitArrayView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/complex_offset.emb.h
+++ b/testdata/golden_cpp/complex_offset.emb.h
@@ -75,21 +75,13 @@ class GenericLengthView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_length().Known()) return false;
-    if (has_length().ValueOrDefault() && !length().Ok()) return false;
+    if (!length().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -474,24 +466,15 @@ class GenericDataView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_length().Known()) return false;
-    if (has_length().ValueOrDefault() && !length().Ok()) return false;
+    if (!length().Ok()) return false;
 
-    if (!has_data().Known()) return false;
-    if (has_data().ValueOrDefault() && !data().Ok()) return false;
+    if (!data().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1005,69 +988,45 @@ class GenericPackedFieldsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_length1().Known()) return false;
-    if (has_length1().ValueOrDefault() && !length1().Ok()) return false;
+    if (!length1().Ok()) return false;
 
-    if (!has_data1().Known()) return false;
-    if (has_data1().ValueOrDefault() && !data1().Ok()) return false;
+    if (!data1().Ok()) return false;
 
-    if (!has_o1().Known()) return false;
-    if (has_o1().ValueOrDefault() && !o1().Ok()) return false;
+    if (!o1().Ok()) return false;
 
-    if (!has_length2().Known()) return false;
-    if (has_length2().ValueOrDefault() && !length2().Ok()) return false;
+    if (!length2().Ok()) return false;
 
-    if (!has_data2().Known()) return false;
-    if (has_data2().ValueOrDefault() && !data2().Ok()) return false;
+    if (!data2().Ok()) return false;
 
-    if (!has_o2().Known()) return false;
-    if (has_o2().ValueOrDefault() && !o2().Ok()) return false;
+    if (!o2().Ok()) return false;
 
-    if (!has_length3().Known()) return false;
-    if (has_length3().ValueOrDefault() && !length3().Ok()) return false;
+    if (!length3().Ok()) return false;
 
-    if (!has_data3().Known()) return false;
-    if (has_data3().ValueOrDefault() && !data3().Ok()) return false;
+    if (!data3().Ok()) return false;
 
-    if (!has_o3().Known()) return false;
-    if (has_o3().ValueOrDefault() && !o3().Ok()) return false;
+    if (!o3().Ok()) return false;
 
-    if (!has_length4().Known()) return false;
-    if (has_length4().ValueOrDefault() && !length4().Ok()) return false;
+    if (!length4().Ok()) return false;
 
-    if (!has_data4().Known()) return false;
-    if (has_data4().ValueOrDefault() && !data4().Ok()) return false;
+    if (!data4().Ok()) return false;
 
-    if (!has_o4().Known()) return false;
-    if (has_o4().ValueOrDefault() && !o4().Ok()) return false;
+    if (!o4().Ok()) return false;
 
-    if (!has_length5().Known()) return false;
-    if (has_length5().ValueOrDefault() && !length5().Ok()) return false;
+    if (!length5().Ok()) return false;
 
-    if (!has_data5().Known()) return false;
-    if (has_data5().ValueOrDefault() && !data5().Ok()) return false;
+    if (!data5().Ok()) return false;
 
-    if (!has_o5().Known()) return false;
-    if (has_o5().ValueOrDefault() && !o5().Ok()) return false;
+    if (!o5().Ok()) return false;
 
-    if (!has_length6().Known()) return false;
-    if (has_length6().ValueOrDefault() && !length6().Ok()) return false;
+    if (!length6().Ok()) return false;
 
-    if (!has_data6().Known()) return false;
-    if (has_data6().ValueOrDefault() && !data6().Ok()) return false;
+    if (!data6().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/complex_structure.emb.h
+++ b/testdata/golden_cpp/complex_structure.emb.h
@@ -83,27 +83,17 @@ class GenericRegisterLayoutView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_l().Known()) return false;
-    if (has_l().ValueOrDefault() && !l().Ok()) return false;
+    if (!l().Ok()) return false;
 
-    if (!has_h().Known()) return false;
-    if (has_h().ValueOrDefault() && !h().Ok()) return false;
+    if (!h().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -633,21 +623,13 @@ class GenericArrayElementView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1042,30 +1024,19 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a0().Known()) return false;
-    if (has_a0().ValueOrDefault() && !a0().Ok()) return false;
+    if (!a0().Ok()) return false;
 
-    if (!has_s0().Known()) return false;
-    if (has_s0().ValueOrDefault() && !s0().Ok()) return false;
+    if (!s0().Ok()) return false;
 
-    if (!has_l0().Known()) return false;
-    if (has_l0().ValueOrDefault() && !l0().Ok()) return false;
+    if (!l0().Ok()) return false;
 
-    if (!has_h0().Known()) return false;
-    if (has_h0().ValueOrDefault() && !h0().Ok()) return false;
+    if (!h0().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1669,41 +1640,25 @@ class GenericComplexView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_s().Known()) return false;
-    if (has_s().ValueOrDefault() && !s().Ok()) return false;
+    if (!s().Ok()) return false;
 
-    if (!has_u().Known()) return false;
-    if (has_u().ValueOrDefault() && !u().Ok()) return false;
+    if (!u().Ok()) return false;
 
-    if (!has_i().Known()) return false;
-    if (has_i().ValueOrDefault() && !i().Ok()) return false;
+    if (!i().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_e1().Known()) return false;
-    if (has_e1().ValueOrDefault() && !e1().Ok()) return false;
+    if (!e1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_a0().Known()) return false;
     if (has_a0().ValueOrDefault() && !a0().Ok()) return false;

--- a/testdata/golden_cpp/condition.emb.h
+++ b/testdata/golden_cpp/condition.emb.h
@@ -298,21 +298,13 @@ class GenericBasicConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -835,21 +827,13 @@ class GenericNegativeConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -1378,24 +1362,15 @@ class GenericConditionalAndUnconditionalOverlappingFinalFieldView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_z().Known()) return false;
-    if (has_z().ValueOrDefault() && !z().Ok()) return false;
+    if (!z().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -1955,21 +1930,13 @@ class GenericConditionalBasicConditionalFieldFirstView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -2449,24 +2416,15 @@ class GenericConditionalAndDynamicLocationView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -3081,21 +3039,13 @@ class GenericConditionUsesMinIntView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -3622,21 +3572,13 @@ class GenericNestedConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -4268,21 +4210,13 @@ class GenericCorrectNestedConditionalView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =
@@ -4917,24 +4851,13 @@ class GenericAlwaysFalseConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
-
-    if (!has_xc().Known()) return false;
-    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5401,21 +5324,11 @@ class GenericOnlyAlwaysFalseConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_xc().Known()) return false;
-    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
-
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5803,18 +5716,11 @@ class GenericEmptyStructView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6134,27 +6040,15 @@ class GenericAlwaysFalseConditionDynamicSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
-
-    if (!has_xc().Known()) return false;
-    if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6760,24 +6654,15 @@ class GenericConditionDoesNotContributeToSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -7413,21 +7298,13 @@ class GenericEnumConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -8046,21 +7923,13 @@ class GenericNegativeEnumConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -8584,21 +8453,13 @@ class GenericLessThanConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -9122,21 +8983,13 @@ class GenericLessThanOrEqualConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -9663,21 +9516,13 @@ class GenericGreaterThanOrEqualConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -10202,21 +10047,13 @@ class GenericGreaterThanConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -10738,24 +10575,15 @@ class GenericRangeConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -11379,24 +11207,15 @@ class GenericReverseRangeConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -12019,24 +11838,15 @@ class GenericAndConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -12651,24 +12461,15 @@ class GenericOrConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -13376,27 +13177,17 @@ class GenericChoiceConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_field().Known()) return false;
-    if (has_field().ValueOrDefault() && !field().Ok()) return false;
+    if (!field().Ok()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xyc().Known()) return false;
     if (has_xyc().ValueOrDefault() && !xyc().Ok()) return false;
@@ -14110,24 +13901,15 @@ class GenericEmbossReservedAnonymousField3View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_has_top().Known()) return false;
-    if (has_has_top().ValueOrDefault() && !has_top().Ok()) return false;
+    if (!has_top().Ok()) return false;
 
-    if (!has_has_bottom().Known()) return false;
-    if (has_has_bottom().ValueOrDefault() && !has_bottom().Ok()) return false;
+    if (!has_bottom().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -14586,23 +14368,13 @@ class GenericContainsBitsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_3().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_3().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_3().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_3().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_has_top().Known()) return false;
     if (has_has_top().ValueOrDefault() && !has_top().Ok()) return false;
@@ -15064,21 +14836,13 @@ class GenericContainsContainsBitsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_condition().Known()) return false;
-    if (has_condition().ValueOrDefault() && !condition().Ok()) return false;
+    if (!condition().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_top().Known()) return false;
     if (has_top().ValueOrDefault() && !top().Ok()) return false;
@@ -15596,27 +15360,17 @@ class GenericType0View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -16153,27 +15907,17 @@ class GenericType1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -16719,21 +16463,13 @@ class GenericConditionalInlineView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_payload_id().Known()) return false;
-    if (has_payload_id().ValueOrDefault() && !payload_id().Ok()) return false;
+    if (!payload_id().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =
@@ -17354,24 +17090,15 @@ class GenericEmbossReservedAnonymousField2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_low().Known()) return false;
-    if (has_low().ValueOrDefault() && !low().Ok()) return false;
+    if (!low().Ok()) return false;
 
-    if (!has_high().Known()) return false;
-    if (has_high().ValueOrDefault() && !high().Ok()) return false;
+    if (!high().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     if (!has_mid().Known()) return false;
     if (has_mid().ValueOrDefault() && !mid().Ok()) return false;
@@ -17907,21 +17634,13 @@ class GenericConditionalAnonymousView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_emboss_reserved_anonymous_field_2().Known()) return false;
     if (has_emboss_reserved_anonymous_field_2().ValueOrDefault() &&
@@ -18572,21 +18291,13 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_enabled().Known()) return false;
-    if (has_enabled().ValueOrDefault() && !enabled().Ok()) return false;
+    if (!enabled().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -18972,23 +18683,13 @@ class GenericConditionalOnFlagView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_enabled().Known()) return false;
     if (has_enabled().ValueOrDefault() && !enabled().Ok()) return false;
@@ -19539,21 +19240,13 @@ class GenericResidualConditionalDiscriminantView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
@@ -20310,21 +20003,13 @@ class GenericBareConditionalDiscriminantView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
@@ -21060,24 +20745,15 @@ class GenericDominatedBareDiscriminantView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_tail().Known()) return false;
-    if (has_tail().ValueOrDefault() && !tail().Ok()) return false;
+    if (!tail().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
@@ -21802,21 +21478,13 @@ class GenericDisjunctionConditionalDiscriminantView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::int32_t>());
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
@@ -22588,21 +22256,13 @@ class GenericSingleEntryConditionalDiscriminantView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
@@ -23245,21 +22905,13 @@ class GenericEnumConditionalDiscriminantView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::emboss::test::OnOff>());
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_tag().Known()) return false;
     if (has_tag().ValueOrDefault() && !tag().Ok()) return false;

--- a/testdata/golden_cpp/dynamic_size.emb.h
+++ b/testdata/golden_cpp/dynamic_size.emb.h
@@ -119,35 +119,21 @@ class GenericMessageView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_header_length().Known()) return false;
-    if (has_header_length().ValueOrDefault() && !header_length().Ok())
-      return false;
+    if (!header_length().Ok()) return false;
 
-    if (!has_message_length().Known()) return false;
-    if (has_message_length().ValueOrDefault() && !message_length().Ok())
-      return false;
+    if (!message_length().Ok()) return false;
 
-    if (!has_padding().Known()) return false;
-    if (has_padding().ValueOrDefault() && !padding().Ok()) return false;
+    if (!padding().Ok()) return false;
 
-    if (!has_message().Known()) return false;
-    if (has_message().ValueOrDefault() && !message().Ok()) return false;
+    if (!message().Ok()) return false;
 
-    if (!has_crc32().Known()) return false;
-    if (has_crc32().ValueOrDefault() && !crc32().Ok()) return false;
+    if (!crc32().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -942,24 +928,15 @@ class GenericImageView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_size().Known()) return false;
-    if (has_size().ValueOrDefault() && !size().Ok()) return false;
+    if (!size().Ok()) return false;
 
-    if (!has_pixels().Known()) return false;
-    if (has_pixels().ValueOrDefault() && !pixels().Ok()) return false;
+    if (!pixels().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1500,36 +1477,23 @@ class GenericTwoRegionsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_b_end().Known()) return false;
-    if (has_b_end().ValueOrDefault() && !b_end().Ok()) return false;
+    if (!b_end().Ok()) return false;
 
-    if (!has_b_start().Known()) return false;
-    if (has_b_start().ValueOrDefault() && !b_start().Ok()) return false;
+    if (!b_start().Ok()) return false;
 
-    if (!has_a_size().Known()) return false;
-    if (has_a_size().ValueOrDefault() && !a_size().Ok()) return false;
+    if (!a_size().Ok()) return false;
 
-    if (!has_a_start().Known()) return false;
-    if (has_a_start().ValueOrDefault() && !a_start().Ok()) return false;
+    if (!a_start().Ok()) return false;
 
-    if (!has_region_a().Known()) return false;
-    if (has_region_a().ValueOrDefault() && !region_a().Ok()) return false;
+    if (!region_a().Ok()) return false;
 
-    if (!has_region_b().Known()) return false;
-    if (has_region_b().ValueOrDefault() && !region_b().Ok()) return false;
+    if (!region_b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -2402,27 +2366,17 @@ class GenericMultipliedSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_width().Known()) return false;
-    if (has_width().ValueOrDefault() && !width().Ok()) return false;
+    if (!width().Ok()) return false;
 
-    if (!has_height().Known()) return false;
-    if (has_height().ValueOrDefault() && !height().Ok()) return false;
+    if (!height().Ok()) return false;
 
-    if (!has_data().Known()) return false;
-    if (has_data().ValueOrDefault() && !data().Ok()) return false;
+    if (!data().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -3035,46 +2989,29 @@ class GenericNegativeTermsInSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_a_minus_b().Known()) return false;
-    if (has_a_minus_b().ValueOrDefault() && !a_minus_b().Ok()) return false;
+    if (!a_minus_b().Ok()) return false;
 
-    if (!has_a_minus_2b().Known()) return false;
-    if (has_a_minus_2b().ValueOrDefault() && !a_minus_2b().Ok()) return false;
+    if (!a_minus_2b().Ok()) return false;
 
-    if (!has_a_minus_b_minus_c().Known()) return false;
-    if (has_a_minus_b_minus_c().ValueOrDefault() && !a_minus_b_minus_c().Ok())
-      return false;
+    if (!a_minus_b_minus_c().Ok()) return false;
 
-    if (!has_ten_minus_a().Known()) return false;
-    if (has_ten_minus_a().ValueOrDefault() && !ten_minus_a().Ok()) return false;
+    if (!ten_minus_a().Ok()) return false;
 
-    if (!has_a_minus_2c().Known()) return false;
-    if (has_a_minus_2c().ValueOrDefault() && !a_minus_2c().Ok()) return false;
+    if (!a_minus_2c().Ok()) return false;
 
-    if (!has_a_minus_c().Known()) return false;
-    if (has_a_minus_c().ValueOrDefault() && !a_minus_c().Ok()) return false;
+    if (!a_minus_c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -4319,24 +4256,15 @@ class GenericNegativeTermInLocationView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -4859,30 +4787,19 @@ class GenericChainedSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_d().Known()) return false;
-    if (has_d().ValueOrDefault() && !d().Ok()) return false;
+    if (!d().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5592,27 +5509,17 @@ class GenericFinalFieldOverlapsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6155,30 +6062,19 @@ class GenericDynamicFinalFieldOverlapsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_d().Known()) return false;
-    if (has_d().ValueOrDefault() && !d().Ok()) return false;
+    if (!d().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6874,24 +6770,15 @@ class GenericDynamicFieldDependsOnLaterFieldView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -7425,27 +7312,17 @@ class GenericDynamicFieldDoesNotAffectSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/enum.emb.h
+++ b/testdata/golden_cpp/enum.emb.h
@@ -108,24 +108,15 @@ class GenericConstantsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_sprocket().Known()) return false;
-    if (has_sprocket().ValueOrDefault() && !sprocket().Ok()) return false;
+    if (!sprocket().Ok()) return false;
 
-    if (!has_geegaw().Known()) return false;
-    if (has_geegaw().ValueOrDefault() && !geegaw().Ok()) return false;
+    if (!geegaw().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1573,22 +1564,13 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_wide_kind_in_bits().Known()) return false;
-    if (has_wide_kind_in_bits().ValueOrDefault() && !wide_kind_in_bits().Ok())
-      return false;
+    if (!wide_kind_in_bits().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1981,32 +1963,19 @@ class GenericManifestEntryView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_kind().Known()) return false;
-    if (has_kind().ValueOrDefault() && !kind().Ok()) return false;
+    if (!kind().Ok()) return false;
 
-    if (!has_count().Known()) return false;
-    if (has_count().ValueOrDefault() && !count().Ok()) return false;
+    if (!count().Ok()) return false;
 
-    if (!has_wide_kind().Known()) return false;
-    if (has_wide_kind().ValueOrDefault() && !wide_kind().Ok()) return false;
+    if (!wide_kind().Ok()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_wide_kind_in_bits().Known()) return false;
     if (has_wide_kind_in_bits().ValueOrDefault() && !wide_kind_in_bits().Ok())
@@ -2746,21 +2715,13 @@ class GenericStructContainingEnumView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_bar().Known()) return false;
-    if (has_bar().ValueOrDefault() && !bar().Ok()) return false;
+    if (!bar().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/enum_case.emb.h
+++ b/testdata/golden_cpp/enum_case.emb.h
@@ -332,27 +332,17 @@ class GenericUseKCamelEnumCaseView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_v().Known()) return false;
-    if (has_v().ValueOrDefault() && !v().Ok()) return false;
+    if (!v().Ok()) return false;
 
-    if (!has_first().Known()) return false;
-    if (has_first().ValueOrDefault() && !first().Ok()) return false;
+    if (!first().Ok()) return false;
 
-    if (!has_v_is_first().Known()) return false;
-    if (has_v_is_first().ValueOrDefault() && !v_is_first().Ok()) return false;
+    if (!v_is_first().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/explicit_sizes.emb.h
+++ b/testdata/golden_cpp/explicit_sizes.emb.h
@@ -83,27 +83,17 @@ class GenericSizedUIntArraysView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_nibble().Known()) return false;
-    if (has_one_nibble().ValueOrDefault() && !one_nibble().Ok()) return false;
+    if (!one_nibble().Ok()) return false;
 
-    if (!has_two_nibble().Known()) return false;
-    if (has_two_nibble().ValueOrDefault() && !two_nibble().Ok()) return false;
+    if (!two_nibble().Ok()) return false;
 
-    if (!has_four_nibble().Known()) return false;
-    if (has_four_nibble().ValueOrDefault() && !four_nibble().Ok()) return false;
+    if (!four_nibble().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -649,27 +639,17 @@ class GenericSizedIntArraysView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_nibble().Known()) return false;
-    if (has_one_nibble().ValueOrDefault() && !one_nibble().Ok()) return false;
+    if (!one_nibble().Ok()) return false;
 
-    if (!has_two_nibble().Known()) return false;
-    if (has_two_nibble().ValueOrDefault() && !two_nibble().Ok()) return false;
+    if (!two_nibble().Ok()) return false;
 
-    if (!has_four_nibble().Known()) return false;
-    if (has_four_nibble().ValueOrDefault() && !four_nibble().Ok()) return false;
+    if (!four_nibble().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1215,27 +1195,17 @@ class GenericSizedEnumArraysView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_nibble().Known()) return false;
-    if (has_one_nibble().ValueOrDefault() && !one_nibble().Ok()) return false;
+    if (!one_nibble().Ok()) return false;
 
-    if (!has_two_nibble().Known()) return false;
-    if (has_two_nibble().ValueOrDefault() && !two_nibble().Ok()) return false;
+    if (!two_nibble().Ok()) return false;
 
-    if (!has_four_nibble().Known()) return false;
-    if (has_four_nibble().ValueOrDefault() && !four_nibble().Ok()) return false;
+    if (!four_nibble().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1784,21 +1754,13 @@ class GenericBitArrayContainerView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_uint_arrays().Known()) return false;
-    if (has_uint_arrays().ValueOrDefault() && !uint_arrays().Ok()) return false;
+    if (!uint_arrays().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/float.emb.h
+++ b/testdata/golden_cpp/float.emb.h
@@ -70,27 +70,15 @@ class GenericFloatsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_float_little_endian().Known()) return false;
-    if (has_float_little_endian().ValueOrDefault() &&
-        !float_little_endian().Ok())
-      return false;
+    if (!float_little_endian().Ok()) return false;
 
-    if (!has_float_big_endian().Known()) return false;
-    if (has_float_big_endian().ValueOrDefault() && !float_big_endian().Ok())
-      return false;
+    if (!float_big_endian().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -564,27 +552,15 @@ class GenericDoublesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_double_little_endian().Known()) return false;
-    if (has_double_little_endian().ValueOrDefault() &&
-        !double_little_endian().Ok())
-      return false;
+    if (!double_little_endian().Ok()) return false;
 
-    if (!has_double_big_endian().Known()) return false;
-    if (has_double_big_endian().ValueOrDefault() && !double_big_endian().Ok())
-      return false;
+    if (!double_big_endian().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/imported.emb.h
+++ b/testdata/golden_cpp/imported.emb.h
@@ -65,21 +65,13 @@ class GenericInnerView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/imported_genfiles.emb.h
+++ b/testdata/golden_cpp/imported_genfiles.emb.h
@@ -66,21 +66,13 @@ class GenericInnerView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/importer.emb.h
+++ b/testdata/golden_cpp/importer.emb.h
@@ -67,24 +67,15 @@ class GenericOuterView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_inner().Known()) return false;
-    if (has_inner().ValueOrDefault() && !inner().Ok()) return false;
+    if (!inner().Ok()) return false;
 
-    if (!has_inner_gen().Known()) return false;
-    if (has_inner_gen().ValueOrDefault() && !inner_gen().Ok()) return false;
+    if (!inner_gen().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/importer2.emb.h
+++ b/testdata/golden_cpp/importer2.emb.h
@@ -66,21 +66,13 @@ class GenericOuter2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_outer().Known()) return false;
-    if (has_outer().ValueOrDefault() && !outer().Ok()) return false;
+    if (!outer().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/inline_type.emb.h
+++ b/testdata/golden_cpp/inline_type.emb.h
@@ -259,25 +259,15 @@ class GenericFooView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_status().Known()) return false;
-    if (has_status().ValueOrDefault() && !status().Ok()) return false;
+    if (!status().Ok()) return false;
 
-    if (!has_secondary_status().Known()) return false;
-    if (has_secondary_status().ValueOrDefault() && !secondary_status().Ok())
-      return false;
+    if (!secondary_status().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/int_sizes.emb.h
+++ b/testdata/golden_cpp/int_sizes.emb.h
@@ -65,42 +65,27 @@ class GenericSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/large_array.emb.h
+++ b/testdata/golden_cpp/large_array.emb.h
@@ -65,25 +65,15 @@ class GenericUIntArrayView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_element_count().Known()) return false;
-    if (has_element_count().ValueOrDefault() && !element_count().Ok())
-      return false;
+    if (!element_count().Ok()) return false;
 
-    if (!has_elements().Known()) return false;
-    if (has_elements().ValueOrDefault() && !elements().Ok()) return false;
+    if (!elements().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/many_conditionals.emb.h
+++ b/testdata/golden_cpp/many_conditionals.emb.h
@@ -79,21 +79,13 @@ class GenericLargeConditionalsView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::uint32_t>());
 
-    if (!has_tag().Known()) return false;
-    if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
+    if (!tag().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =
@@ -9903,21 +9895,13 @@ class GenericDisjunctionConditionalsView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::std::uint32_t>());
 
-    if (!has_tag().Known()) return false;
-    if (has_tag().ValueOrDefault() && !tag().Ok()) return false;
+    if (!tag().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =

--- a/testdata/golden_cpp/nested_structure.emb.h
+++ b/testdata/golden_cpp/nested_structure.emb.h
@@ -75,28 +75,17 @@ class GenericContainerView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_weight().Known()) return false;
-    if (has_weight().ValueOrDefault() && !weight().Ok()) return false;
+    if (!weight().Ok()) return false;
 
-    if (!has_important_box().Known()) return false;
-    if (has_important_box().ValueOrDefault() && !important_box().Ok())
-      return false;
+    if (!important_box().Ok()) return false;
 
-    if (!has_other_box().Known()) return false;
-    if (has_other_box().ValueOrDefault() && !other_box().Ok()) return false;
+    if (!other_box().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -627,24 +616,15 @@ class GenericBoxView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_id().Known()) return false;
-    if (has_id().ValueOrDefault() && !id().Ok()) return false;
+    if (!id().Ok()) return false;
 
-    if (!has_count().Known()) return false;
-    if (has_count().ValueOrDefault() && !count().Ok()) return false;
+    if (!count().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1104,24 +1084,15 @@ class GenericTruckView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_id().Known()) return false;
-    if (has_id().ValueOrDefault() && !id().Ok()) return false;
+    if (!id().Ok()) return false;
 
-    if (!has_cargo().Known()) return false;
-    if (has_cargo().ValueOrDefault() && !cargo().Ok()) return false;
+    if (!cargo().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/next_keyword.emb.h
+++ b/testdata/golden_cpp/next_keyword.emb.h
@@ -65,31 +65,19 @@ class GenericNextKeywordView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_value32().Known()) return false;
-    if (has_value32().ValueOrDefault() && !value32().Ok()) return false;
+    if (!value32().Ok()) return false;
 
-    if (!has_value16().Known()) return false;
-    if (has_value16().ValueOrDefault() && !value16().Ok()) return false;
+    if (!value16().Ok()) return false;
 
-    if (!has_value8().Known()) return false;
-    if (has_value8().ValueOrDefault() && !value8().Ok()) return false;
+    if (!value8().Ok()) return false;
 
-    if (!has_value8_offset().Known()) return false;
-    if (has_value8_offset().ValueOrDefault() && !value8_offset().Ok())
-      return false;
+    if (!value8_offset().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/no_enum_traits.emb.h
+++ b/testdata/golden_cpp/no_enum_traits.emb.h
@@ -144,21 +144,13 @@ class GenericBarView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_foo().Known()) return false;
-    if (has_foo().ValueOrDefault() && !foo().Ok()) return false;
+    if (!foo().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/parameters.emb.h
+++ b/testdata/golden_cpp/parameters.emb.h
@@ -358,21 +358,13 @@ class GenericMultiVersionView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::emboss::test::MessageId>());
 
-    if (!has_message_id().Known()) return false;
-    if (has_message_id().ValueOrDefault() && !message_id().Ok()) return false;
+    if (!message_id().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =
@@ -1151,26 +1143,15 @@ class GenericAxesView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_values().Known()) return false;
-    if (has_values().ValueOrDefault() && !values().Ok()) return false;
+    if (!values().Ok()) return false;
 
-    if (!has_axis_count_plus_one().Known()) return false;
-    if (has_axis_count_plus_one().ValueOrDefault() &&
-        !axis_count_plus_one().Ok())
-      return false;
+    if (!axis_count_plus_one().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
@@ -2036,30 +2017,19 @@ class GenericAxisPairView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_axis_type_a().Known()) return false;
-    if (has_axis_type_a().ValueOrDefault() && !axis_type_a().Ok()) return false;
+    if (!axis_type_a().Ok()) return false;
 
-    if (!has_axis_a().Known()) return false;
-    if (has_axis_a().ValueOrDefault() && !axis_a().Ok()) return false;
+    if (!axis_a().Ok()) return false;
 
-    if (!has_axis_type_b().Known()) return false;
-    if (has_axis_type_b().ValueOrDefault() && !axis_type_b().Ok()) return false;
+    if (!axis_type_b().Ok()) return false;
 
-    if (!has_axis_b().Known()) return false;
-    if (has_axis_b().ValueOrDefault() && !axis_b().Ok()) return false;
+    if (!axis_b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -2800,24 +2770,15 @@ class GenericAxesEnvelopeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_axis_count().Known()) return false;
-    if (has_axis_count().ValueOrDefault() && !axis_count().Ok()) return false;
+    if (!axis_count().Ok()) return false;
 
-    if (!has_axes().Known()) return false;
-    if (has_axes().ValueOrDefault() && !axes().Ok()) return false;
+    if (!axes().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -3471,24 +3432,15 @@ class GenericAxisView final {
                        emboss_reserved_local_ok_subexpr_1.UncheckedRead()))
              : ::emboss::support::Maybe</**/ ::emboss::test::AxisType>());
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_axis_type().Known()) return false;
-    if (has_axis_type().ValueOrDefault() && !axis_type().Ok()) return false;
+    if (!axis_type().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     {
       const auto emboss_reserved_switch_discrim =
@@ -4258,21 +4210,13 @@ class GenericConfigView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_power().Known()) return false;
-    if (has_power().ValueOrDefault() && !power().Ok()) return false;
+    if (!power().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -4661,21 +4605,13 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_power().Known()) return false;
-    if (has_power().ValueOrDefault() && !power().Ok()) return false;
+    if (!power().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -5060,26 +4996,15 @@ class GenericConfigVXView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_gain().Known()) return false;
-    if (has_gain().ValueOrDefault() && !gain().Ok()) return false;
+    if (!gain().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_power().Known()) return false;
     if (has_power().ValueOrDefault() && !power().Ok()) return false;
@@ -5575,21 +5500,13 @@ class GenericStructWithUnusedParameterView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6031,24 +5948,15 @@ class GenericStructContainingStructWithUnusedParameterView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_swup().Known()) return false;
-    if (has_swup().ValueOrDefault() && !swup().Ok()) return false;
+    if (!swup().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6529,24 +6437,15 @@ class GenericBiasedValueView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_raw_value().Known()) return false;
-    if (has_raw_value().ValueOrDefault() && !raw_value().Ok()) return false;
+    if (!raw_value().Ok()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -7088,24 +6987,15 @@ class GenericVirtualFirstFieldWithParamView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -7600,24 +7490,15 @@ class GenericConstVirtualFirstFieldWithParamView final {
     if (!IsComplete()) return false;
     if (!parameters_initialized_) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -8113,28 +7994,17 @@ class GenericSizedArrayOfBiasedValuesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_element_count().Known()) return false;
-    if (has_element_count().ValueOrDefault() && !element_count().Ok())
-      return false;
+    if (!element_count().Ok()) return false;
 
-    if (!has_bias().Known()) return false;
-    if (has_bias().ValueOrDefault() && !bias().Ok()) return false;
+    if (!bias().Ok()) return false;
 
-    if (!has_values().Known()) return false;
-    if (has_values().ValueOrDefault() && !values().Ok()) return false;
+    if (!values().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/requires.emb.h
+++ b/testdata/golden_cpp/requires.emb.h
@@ -201,43 +201,23 @@ class GenericRequiresIntegersView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_zero_through_nine().Known()) return false;
-    if (has_zero_through_nine().ValueOrDefault() && !zero_through_nine().Ok())
-      return false;
+    if (!zero_through_nine().Ok()) return false;
 
-    if (!has_ten_through_twenty().Known()) return false;
-    if (has_ten_through_twenty().ValueOrDefault() && !ten_through_twenty().Ok())
-      return false;
+    if (!ten_through_twenty().Ok()) return false;
 
-    if (!has_disjoint().Known()) return false;
-    if (has_disjoint().ValueOrDefault() && !disjoint().Ok()) return false;
+    if (!disjoint().Ok()) return false;
 
-    if (!has_ztn_plus_ttt().Known()) return false;
-    if (has_ztn_plus_ttt().ValueOrDefault() && !ztn_plus_ttt().Ok())
-      return false;
+    if (!ztn_plus_ttt().Ok()) return false;
 
-    if (!has_alias_of_zero_through_nine().Known()) return false;
-    if (has_alias_of_zero_through_nine().ValueOrDefault() &&
-        !alias_of_zero_through_nine().Ok())
-      return false;
+    if (!alias_of_zero_through_nine().Ok()) return false;
 
-    if (!has_zero_through_nine_plus_five().Known()) return false;
-    if (has_zero_through_nine_plus_five().ValueOrDefault() &&
-        !zero_through_nine_plus_five().Ok())
-      return false;
+    if (!zero_through_nine_plus_five().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!(::emboss::support::LessThanOrEqual</**/ ::std::int32_t, bool,
                                              ::std::int32_t, ::std::int32_t>(
@@ -1289,32 +1269,19 @@ class GenericEmbossReservedAnonymousField2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_must_be_true().Known()) return false;
-    if (has_must_be_true().ValueOrDefault() && !must_be_true().Ok())
-      return false;
+    if (!must_be_true().Ok()) return false;
 
-    if (!has_must_be_false().Known()) return false;
-    if (has_must_be_false().ValueOrDefault() && !must_be_false().Ok())
-      return false;
+    if (!must_be_false().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -1925,32 +1892,17 @@ class GenericRequiresBoolsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_2().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_2().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_2().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_2().Ok()) return false;
 
-    if (!has_b_must_be_false().Known()) return false;
-    if (has_b_must_be_false().ValueOrDefault() && !b_must_be_false().Ok())
-      return false;
+    if (!b_must_be_false().Ok()) return false;
 
-    if (!has_alias_of_a_must_be_true().Known()) return false;
-    if (has_alias_of_a_must_be_true().ValueOrDefault() &&
-        !alias_of_a_must_be_true().Ok())
-      return false;
+    if (!alias_of_a_must_be_true().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_a().Known()) return false;
     if (has_a().ValueOrDefault() && !a().Ok()) return false;
@@ -2899,33 +2851,21 @@ class GenericRequiresEnumsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_filtered_a().Known()) return false;
-    if (has_filtered_a().ValueOrDefault() && !filtered_a().Ok()) return false;
+    if (!filtered_a().Ok()) return false;
 
-    if (!has_alias_of_a().Known()) return false;
-    if (has_alias_of_a().ValueOrDefault() && !alias_of_a().Ok()) return false;
+    if (!alias_of_a().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!(::emboss::support::Or</**/ bool, bool, bool, bool>(
               ::emboss::support::Equal</**/ ::emboss::test::RequiresEnums::Enum,
@@ -3792,24 +3732,15 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b_exists().Known()) return false;
-    if (has_b_exists().ValueOrDefault() && !b_exists().Ok()) return false;
+    if (!b_exists().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     if (!has_b().Known()) return false;
     if (has_b().ValueOrDefault() && !b().Ok()) return false;
@@ -4472,23 +4403,13 @@ class GenericRequiresWithOptionalFieldsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_a().Known()) return false;
     if (has_a().ValueOrDefault() && !a().Ok()) return false;
@@ -5077,21 +4998,13 @@ class GenericElementView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5479,21 +5392,13 @@ class GenericRequiresInArrayElementsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_xs().Known()) return false;
-    if (has_xs().ValueOrDefault() && !xs().Ok()) return false;
+    if (!xs().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/start_size_range.emb.h
+++ b/testdata/golden_cpp/start_size_range.emb.h
@@ -65,32 +65,19 @@ class GenericStartSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_size().Known()) return false;
-    if (has_size().ValueOrDefault() && !size().Ok()) return false;
+    if (!size().Ok()) return false;
 
-    if (!has_start_size_constants().Known()) return false;
-    if (has_start_size_constants().ValueOrDefault() &&
-        !start_size_constants().Ok())
-      return false;
+    if (!start_size_constants().Ok()) return false;
 
-    if (!has_payload().Known()) return false;
-    if (has_payload().ValueOrDefault() && !payload().Ok()) return false;
+    if (!payload().Ok()) return false;
 
-    if (!has_counter().Known()) return false;
-    if (has_counter().ValueOrDefault() && !counter().Ok()) return false;
+    if (!counter().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/subtypes.emb.h
+++ b/testdata/golden_cpp/subtypes.emb.h
@@ -182,28 +182,17 @@ class GenericInInView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_outer_offset().Known()) return false;
-    if (has_outer_offset().ValueOrDefault() && !outer_offset().Ok())
-      return false;
+    if (!outer_offset().Ok()) return false;
 
-    if (!has_field_enum().Known()) return false;
-    if (has_field_enum().ValueOrDefault() && !field_enum().Ok()) return false;
+    if (!field_enum().Ok()) return false;
 
-    if (!has_in_2().Known()) return false;
-    if (has_in_2().ValueOrDefault() && !in_2().Ok()) return false;
+    if (!in_2().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -714,39 +703,23 @@ class GenericInView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_in_in_1().Known()) return false;
-    if (has_in_in_1().ValueOrDefault() && !in_in_1().Ok()) return false;
+    if (!in_in_1().Ok()) return false;
 
-    if (!has_in_in_2().Known()) return false;
-    if (has_in_in_2().ValueOrDefault() && !in_in_2().Ok()) return false;
+    if (!in_in_2().Ok()) return false;
 
-    if (!has_in_in_in_1().Known()) return false;
-    if (has_in_in_in_1().ValueOrDefault() && !in_in_in_1().Ok()) return false;
+    if (!in_in_in_1().Ok()) return false;
 
-    if (!has_in_2().Known()) return false;
-    if (has_in_2().ValueOrDefault() && !in_2().Ok()) return false;
+    if (!in_2().Ok()) return false;
 
-    if (!has_name_collision().Known()) return false;
-    if (has_name_collision().ValueOrDefault() && !name_collision().Ok())
-      return false;
+    if (!name_collision().Ok()) return false;
 
-    if (!has_name_collision_check().Known()) return false;
-    if (has_name_collision_check().ValueOrDefault() &&
-        !name_collision_check().Ok())
-      return false;
+    if (!name_collision_check().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1565,21 +1538,13 @@ class GenericIn2View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_field_byte().Known()) return false;
-    if (has_field_byte().ValueOrDefault() && !field_byte().Ok()) return false;
+    if (!field_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1963,45 +1928,27 @@ class GenericOutView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_in_1().Known()) return false;
-    if (has_in_1().ValueOrDefault() && !in_1().Ok()) return false;
+    if (!in_1().Ok()) return false;
 
-    if (!has_in_2().Known()) return false;
-    if (has_in_2().ValueOrDefault() && !in_2().Ok()) return false;
+    if (!in_2().Ok()) return false;
 
-    if (!has_in_in_1().Known()) return false;
-    if (has_in_in_1().ValueOrDefault() && !in_in_1().Ok()) return false;
+    if (!in_in_1().Ok()) return false;
 
-    if (!has_in_in_2().Known()) return false;
-    if (has_in_in_2().ValueOrDefault() && !in_in_2().Ok()) return false;
+    if (!in_in_2().Ok()) return false;
 
-    if (!has_in_in_in_1().Known()) return false;
-    if (has_in_in_in_1().ValueOrDefault() && !in_in_in_1().Ok()) return false;
+    if (!in_in_in_1().Ok()) return false;
 
-    if (!has_in_in_in_2().Known()) return false;
-    if (has_in_in_in_2().ValueOrDefault() && !in_in_in_2().Ok()) return false;
+    if (!in_in_in_2().Ok()) return false;
 
-    if (!has_name_collision().Known()) return false;
-    if (has_name_collision().ValueOrDefault() && !name_collision().Ok())
-      return false;
+    if (!name_collision().Ok()) return false;
 
-    if (!has_nested_constant_check().Known()) return false;
-    if (has_nested_constant_check().ValueOrDefault() &&
-        !nested_constant_check().Ok())
-      return false;
+    if (!nested_constant_check().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/text_format.emb.h
+++ b/testdata/golden_cpp/text_format.emb.h
@@ -77,24 +77,15 @@ class GenericVanillaView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -558,27 +549,17 @@ class GenericStructWithSkippedFieldsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1095,27 +1076,17 @@ class GenericStructWithSkippedStructureFieldsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_c().Known()) return false;
-    if (has_c().ValueOrDefault() && !c().Ok()) return false;
+    if (!c().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/uint_sizes.emb.h
+++ b/testdata/golden_cpp/uint_sizes.emb.h
@@ -102,42 +102,27 @@ class GenericSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1055,42 +1040,27 @@ class GenericBigEndianSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -2013,42 +1983,27 @@ class GenericAlternatingEndianSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -2968,42 +2923,27 @@ class GenericEnumSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -3939,23 +3879,13 @@ class GenericEmbossReservedAnonymousField1View final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_three_and_a_half_byte().Known()) return false;
-    if (has_three_and_a_half_byte().ValueOrDefault() &&
-        !three_and_a_half_byte().Ok())
-      return false;
+    if (!three_and_a_half_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -4356,32 +4286,19 @@ class GenericExplicitlySizedEnumSizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_emboss_reserved_anonymous_field_1().Known()) return false;
-    if (has_emboss_reserved_anonymous_field_1().ValueOrDefault() &&
-        !emboss_reserved_anonymous_field_1().Ok())
-      return false;
+    if (!emboss_reserved_anonymous_field_1().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_three_and_a_half_byte().Known()) return false;
     if (has_three_and_a_half_byte().ValueOrDefault() &&
@@ -5358,42 +5275,27 @@ class GenericArraySizesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_one_byte().Known()) return false;
-    if (has_one_byte().ValueOrDefault() && !one_byte().Ok()) return false;
+    if (!one_byte().Ok()) return false;
 
-    if (!has_two_byte().Known()) return false;
-    if (has_two_byte().ValueOrDefault() && !two_byte().Ok()) return false;
+    if (!two_byte().Ok()) return false;
 
-    if (!has_three_byte().Known()) return false;
-    if (has_three_byte().ValueOrDefault() && !three_byte().Ok()) return false;
+    if (!three_byte().Ok()) return false;
 
-    if (!has_four_byte().Known()) return false;
-    if (has_four_byte().ValueOrDefault() && !four_byte().Ok()) return false;
+    if (!four_byte().Ok()) return false;
 
-    if (!has_five_byte().Known()) return false;
-    if (has_five_byte().ValueOrDefault() && !five_byte().Ok()) return false;
+    if (!five_byte().Ok()) return false;
 
-    if (!has_six_byte().Known()) return false;
-    if (has_six_byte().ValueOrDefault() && !six_byte().Ok()) return false;
+    if (!six_byte().Ok()) return false;
 
-    if (!has_seven_byte().Known()) return false;
-    if (has_seven_byte().ValueOrDefault() && !seven_byte().Ok()) return false;
+    if (!seven_byte().Ok()) return false;
 
-    if (!has_eight_byte().Known()) return false;
-    if (has_eight_byte().ValueOrDefault() && !eight_byte().Ok()) return false;
+    if (!eight_byte().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }

--- a/testdata/golden_cpp/virtual_field.emb.h
+++ b/testdata/golden_cpp/virtual_field.emb.h
@@ -181,56 +181,31 @@ class GenericStructureWithConstantsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_ten().Known()) return false;
-    if (has_ten().ValueOrDefault() && !ten().Ok()) return false;
+    if (!ten().Ok()) return false;
 
-    if (!has_twenty().Known()) return false;
-    if (has_twenty().ValueOrDefault() && !twenty().Ok()) return false;
+    if (!twenty().Ok()) return false;
 
-    if (!has_four_billion().Known()) return false;
-    if (has_four_billion().ValueOrDefault() && !four_billion().Ok())
-      return false;
+    if (!four_billion().Ok()) return false;
 
-    if (!has_ten_billion().Known()) return false;
-    if (has_ten_billion().ValueOrDefault() && !ten_billion().Ok()) return false;
+    if (!ten_billion().Ok()) return false;
 
-    if (!has_minus_ten_billion().Known()) return false;
-    if (has_minus_ten_billion().ValueOrDefault() && !minus_ten_billion().Ok())
-      return false;
+    if (!minus_ten_billion().Ok()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_alias_of_value().Known()) return false;
-    if (has_alias_of_value().ValueOrDefault() && !alias_of_value().Ok())
-      return false;
+    if (!alias_of_value().Ok()) return false;
 
-    if (!has_alias_of_alias_of_value().Known()) return false;
-    if (has_alias_of_alias_of_value().ValueOrDefault() &&
-        !alias_of_alias_of_value().Ok())
-      return false;
+    if (!alias_of_alias_of_value().Ok()) return false;
 
-    if (!has_alias_of_ten().Known()) return false;
-    if (has_alias_of_ten().ValueOrDefault() && !alias_of_ten().Ok())
-      return false;
+    if (!alias_of_ten().Ok()) return false;
 
-    if (!has_alias_of_alias_of_ten().Known()) return false;
-    if (has_alias_of_alias_of_ten().ValueOrDefault() &&
-        !alias_of_alias_of_ten().Ok())
-      return false;
+    if (!alias_of_alias_of_ten().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -1113,41 +1088,25 @@ class GenericStructureWithComputedValuesView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_value().Known()) return false;
-    if (has_value().ValueOrDefault() && !value().Ok()) return false;
+    if (!value().Ok()) return false;
 
-    if (!has_doubled().Known()) return false;
-    if (has_doubled().ValueOrDefault() && !doubled().Ok()) return false;
+    if (!doubled().Ok()) return false;
 
-    if (!has_plus_ten().Known()) return false;
-    if (has_plus_ten().ValueOrDefault() && !plus_ten().Ok()) return false;
+    if (!plus_ten().Ok()) return false;
 
-    if (!has_value2().Known()) return false;
-    if (has_value2().ValueOrDefault() && !value2().Ok()) return false;
+    if (!value2().Ok()) return false;
 
-    if (!has_signed_doubled().Known()) return false;
-    if (has_signed_doubled().ValueOrDefault() && !signed_doubled().Ok())
-      return false;
+    if (!signed_doubled().Ok()) return false;
 
-    if (!has_signed_plus_ten().Known()) return false;
-    if (has_signed_plus_ten().ValueOrDefault() && !signed_plus_ten().Ok())
-      return false;
+    if (!signed_plus_ten().Ok()) return false;
 
-    if (!has_product().Known()) return false;
-    if (has_product().ValueOrDefault() && !product().Ok()) return false;
+    if (!product().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -2229,24 +2188,15 @@ class GenericStructureWithConditionalValueView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_x_plus_one().Known()) return false;
-    if (has_x_plus_one().ValueOrDefault() && !x_plus_one().Ok()) return false;
+    if (!x_plus_one().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_two_x().Known()) return false;
     if (has_two_x().ValueOrDefault() && !two_x().Ok()) return false;
@@ -2900,24 +2850,15 @@ class GenericStructureWithValueInConditionView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_two_x().Known()) return false;
-    if (has_two_x().ValueOrDefault() && !two_x().Ok()) return false;
+    if (!two_x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_if_two_x_lt_100().Known()) return false;
     if (has_if_two_x_lt_100().ValueOrDefault() && !if_two_x_lt_100().Ok())
@@ -3546,31 +3487,19 @@ class GenericStructureWithValuesInLocationView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_two_x().Known()) return false;
-    if (has_two_x().ValueOrDefault() && !two_x().Ok()) return false;
+    if (!two_x().Ok()) return false;
 
-    if (!has_offset_two_x().Known()) return false;
-    if (has_offset_two_x().ValueOrDefault() && !offset_two_x().Ok())
-      return false;
+    if (!offset_two_x().Ok()) return false;
 
-    if (!has_size_two_x().Known()) return false;
-    if (has_size_two_x().ValueOrDefault() && !size_two_x().Ok()) return false;
+    if (!size_two_x().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -4277,24 +4206,15 @@ class GenericStructureWithBoolValueView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_x_is_ten().Known()) return false;
-    if (has_x_is_ten().ValueOrDefault() && !x_is_ten().Ok()) return false;
+    if (!x_is_ten().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -4871,24 +4791,15 @@ class GenericStructureWithEnumValueView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_x_size().Known()) return false;
-    if (has_x_size().ValueOrDefault() && !x_size().Ok()) return false;
+    if (!x_size().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5389,29 +5300,17 @@ class GenericStructureWithBitsWithValueView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_alias_of_b_sum().Known()) return false;
-    if (has_alias_of_b_sum().ValueOrDefault() && !alias_of_b_sum().Ok())
-      return false;
+    if (!alias_of_b_sum().Ok()) return false;
 
-    if (!has_alias_of_b_a().Known()) return false;
-    if (has_alias_of_b_a().ValueOrDefault() && !alias_of_b_a().Ok())
-      return false;
+    if (!alias_of_b_a().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -5930,27 +5829,17 @@ class GenericBitsWithValueView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a().Known()) return false;
-    if (has_a().ValueOrDefault() && !a().Ok()) return false;
+    if (!a().Ok()) return false;
 
-    if (!has_b().Known()) return false;
-    if (has_b().ValueOrDefault() && !b().Ok()) return false;
+    if (!b().Ok()) return false;
 
-    if (!has_sum().Known()) return false;
-    if (has_sum().ValueOrDefault() && !sum().Ok()) return false;
+    if (!sum().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -6509,24 +6398,15 @@ class GenericStructureUsingForeignConstantsView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_one_hundred().Known()) return false;
-    if (has_one_hundred().ValueOrDefault() && !one_hundred().Ok()) return false;
+    if (!one_hundred().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -6974,24 +6854,15 @@ class GenericHeaderView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_size().Known()) return false;
-    if (has_size().ValueOrDefault() && !size().Ok()) return false;
+    if (!size().Ok()) return false;
 
-    if (!has_message_id().Known()) return false;
-    if (has_message_id().ValueOrDefault() && !message_id().Ok()) return false;
+    if (!message_id().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -7453,27 +7324,17 @@ class GenericSubfieldOfAliasView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_header().Known()) return false;
-    if (has_header().ValueOrDefault() && !header().Ok()) return false;
+    if (!header().Ok()) return false;
 
-    if (!has_h().Known()) return false;
-    if (has_h().ValueOrDefault() && !h().Ok()) return false;
+    if (!h().Ok()) return false;
 
-    if (!has_size().Known()) return false;
-    if (has_size().ValueOrDefault() && !size().Ok()) return false;
+    if (!size().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -7944,25 +7805,15 @@ class GenericRestrictedAliasView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_a_b().Known()) return false;
-    if (has_a_b().ValueOrDefault() && !a_b().Ok()) return false;
+    if (!a_b().Ok()) return false;
 
-    if (!has_alias_switch().Known()) return false;
-    if (has_alias_switch().ValueOrDefault() && !alias_switch().Ok())
-      return false;
+    if (!alias_switch().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_a_b_alias().Known()) return false;
     if (has_a_b_alias().ValueOrDefault() && !a_b_alias().Ok()) return false;
@@ -8473,21 +8324,13 @@ class GenericXView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_v().Known()) return false;
-    if (has_v().ValueOrDefault() && !v().Ok()) return false;
+    if (!v().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_y().Known()) return false;
     if (has_y().ValueOrDefault() && !y().Ok()) return false;
@@ -9001,21 +8844,13 @@ class GenericHasFieldView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_z().Known()) return false;
-    if (has_z().ValueOrDefault() && !z().Ok()) return false;
+    if (!z().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_x().Known()) return false;
     if (has_x().ValueOrDefault() && !x().Ok()) return false;
@@ -9662,24 +9497,15 @@ class GenericVirtualUnconditionallyUsesConditionalView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_x_nor_xc().Known()) return false;
-    if (has_x_nor_xc().ValueOrDefault() && !x_nor_xc().Ok()) return false;
+    if (!x_nor_xc().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     if (!has_xc().Known()) return false;
     if (has_xc().ValueOrDefault() && !xc().Ok()) return false;
@@ -10315,25 +10141,15 @@ class GenericRView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_q().Known()) return false;
-    if (has_q().ValueOrDefault() && !q().Ok()) return false;
+    if (!q().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBits().Known()) return false;
-    if (has_IntrinsicSizeInBits().ValueOrDefault() &&
-        !IntrinsicSizeInBits().Ok())
-      return false;
+    if (!IntrinsicSizeInBits().Ok()) return false;
 
-    if (!has_q_plus_bit_size().Known()) return false;
-    if (has_q_plus_bit_size().ValueOrDefault() && !q_plus_bit_size().Ok())
-      return false;
+    if (!q_plus_bit_size().Ok()) return false;
 
-    if (!has_MaxSizeInBits().Known()) return false;
-    if (has_MaxSizeInBits().ValueOrDefault() && !MaxSizeInBits().Ok())
-      return false;
+    if (!MaxSizeInBits().Ok()) return false;
 
-    if (!has_MinSizeInBits().Known()) return false;
-    if (has_MinSizeInBits().ValueOrDefault() && !MinSizeInBits().Ok())
-      return false;
+    if (!MinSizeInBits().Ok()) return false;
 
     return true;
   }
@@ -10802,25 +10618,15 @@ class GenericUsesSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_r().Known()) return false;
-    if (has_r().ValueOrDefault() && !r().Ok()) return false;
+    if (!r().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_r_q_plus_byte_size().Known()) return false;
-    if (has_r_q_plus_byte_size().ValueOrDefault() && !r_q_plus_byte_size().Ok())
-      return false;
+    if (!r_q_plus_byte_size().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -11299,24 +11105,15 @@ class GenericUsesExternalSizeView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_y().Known()) return false;
-    if (has_y().ValueOrDefault() && !y().Ok()) return false;
+    if (!y().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }
@@ -11771,38 +11568,23 @@ class GenericImplicitWriteBackView final {
   bool Ok() const {
     if (!IsComplete()) return false;
 
-    if (!has_x().Known()) return false;
-    if (has_x().ValueOrDefault() && !x().Ok()) return false;
+    if (!x().Ok()) return false;
 
-    if (!has_x_plus_ten().Known()) return false;
-    if (has_x_plus_ten().ValueOrDefault() && !x_plus_ten().Ok()) return false;
+    if (!x_plus_ten().Ok()) return false;
 
-    if (!has_ten_plus_x().Known()) return false;
-    if (has_ten_plus_x().ValueOrDefault() && !ten_plus_x().Ok()) return false;
+    if (!ten_plus_x().Ok()) return false;
 
-    if (!has_x_minus_ten().Known()) return false;
-    if (has_x_minus_ten().ValueOrDefault() && !x_minus_ten().Ok()) return false;
+    if (!x_minus_ten().Ok()) return false;
 
-    if (!has_ten_minus_x().Known()) return false;
-    if (has_ten_minus_x().ValueOrDefault() && !ten_minus_x().Ok()) return false;
+    if (!ten_minus_x().Ok()) return false;
 
-    if (!has_ten_minus_x_plus_ten().Known()) return false;
-    if (has_ten_minus_x_plus_ten().ValueOrDefault() &&
-        !ten_minus_x_plus_ten().Ok())
-      return false;
+    if (!ten_minus_x_plus_ten().Ok()) return false;
 
-    if (!has_IntrinsicSizeInBytes().Known()) return false;
-    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
-        !IntrinsicSizeInBytes().Ok())
-      return false;
+    if (!IntrinsicSizeInBytes().Ok()) return false;
 
-    if (!has_MaxSizeInBytes().Known()) return false;
-    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
-      return false;
+    if (!MaxSizeInBytes().Ok()) return false;
 
-    if (!has_MinSizeInBytes().Known()) return false;
-    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
-      return false;
+    if (!MinSizeInBytes().Ok()) return false;
 
     return true;
   }


### PR DESCRIPTION
Many Emboss schemas have fields whose `existence_condition` the front end has already constant-folded to a boolean literal:

  * `if false:` fields are never present, so `Ok()` needs no check for them at all. PR #241 still emitted the full `has_X()` guard + `Ok()` check; both branches are dead.
  * Unconditional fields (and `if true:` fields) carry a literal `true` existence. `has_X()` is always `Known` and always true, so the standard `ok_method_test` pattern collapses from two lines to one bare `if (!x().Ok()) return false;` check.

A fast pre-pass in `_generate_optimized_ok_method_body` recognizes both shapes and routes them to the short emit paths. `if false:` fields are skipped; the always-true case emits the bare `Ok()` check. All unconditional fields share one group so they emit contiguously at the position of the first such field — preserves PR #241's field-batching shape so the compiler's view of the function body stays tight.

The docstring on `_generate_optimized_ok_method_body` is rewritten to describe the four emit paths the function now routes fields through (skipped / unconditional / switch arm / `ok_method_test`).

### Size impact (cumulative vs. master)

| Target | Metric | Master | PR | Delta |
|---|---|---:|---:|---:|
| ARM Thumb-2 | TU .text | 18962 | 17974 | −988 (−5.2%) |
| ARM Thumb-2 | LargeConditionals::Ok() | 5382 | 4930 | −452 (−8.4%) |
| ARM Thumb-2 | DisjunctionConditionals::Ok() | 358 | 262 | −96 (−26.8%) |
| MicroBlaze | TU .text | 43640 | 35796 | −7844 (−18.0%) |
| MicroBlaze | LargeConditionals::Ok() | 14824 | 8308 | −6516 (−44.0%) |
| MicroBlaze | DisjunctionConditionals::Ok() | 640 | 532 | −108 (−16.9%) |
| Host x86-64 | TU .text | 29166 | 28242 | −924 (−3.2%) |
| Host x86-64 | LargeConditionals::Ok() | 3948 | 3040 | −908 (−23.0%) |
| Host x86-64 | DisjunctionConditionals::Ok() | 431 | 354 | −77 (−17.9%) |

**Incremental delta vs. #258: 0 across the board.** The C++ compiler optimizes both source patterns identically at `-Os`, so this PR is a source-quality improvement (32 golden headers shrink by hundreds of lines apiece, generated code is easier to read) with no runtime machine-code cost.

Stacked on #258.
