### PR TITLE
Add missing applicable licenses to BUILD files

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,6 +1,7 @@
 {
   // A list of all source files required to build the Emboss compiler.
   "embossc_sources": [
+    "/LICENSE",
     "compiler/__init__.py",
     "compiler/back_end/__init__.py",
     "compiler/back_end/cpp/__init__.py",
@@ -49,6 +50,7 @@
   ],
   // A list of all source files required for the Emboss C++ runtime.
   "emboss_runtime_cpp_sources": [
+    "/LICENSE",
     "runtime/cpp/emboss_arithmetic.h",
     "runtime/cpp/emboss_arithmetic_all_known_generated.h",
     "runtime/cpp/emboss_arithmetic_maximum_operation_generated.h",

--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -20,6 +20,7 @@ load("@rules_python//python:py_test.bzl", "py_test")
 load(":build_defs.bzl", "cpp_golden_test", "emboss_cc_test")
 
 package(
+    default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//visibility:private",
     ],

--- a/compiler/back_end/util/BUILD
+++ b/compiler/back_end/util/BUILD
@@ -18,6 +18,7 @@ load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
 
 package(
+    default_applicable_licenses = ["//:license"],
     default_visibility = ["//compiler:__subpackages__"],
 )
 

--- a/compiler/front_end/BUILD
+++ b/compiler/front_end/BUILD
@@ -23,6 +23,7 @@ load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
 
 package(
+    default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//:__subpackages__",
     ],

--- a/compiler/util/BUILD
+++ b/compiler/util/BUILD
@@ -18,6 +18,7 @@ load("@rules_python//python:py_library.bzl", "py_library")
 load("@rules_python//python:py_test.bzl", "py_test")
 
 package(
+    default_applicable_licenses = ["//:license"],
     default_visibility = ["//compiler:__subpackages__"],
 )
 

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -1,3 +1,6 @@
+package(
+    default_applicable_licenses = ["//:license"],
+)
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/integration/googletest/BUILD
+++ b/integration/googletest/BUILD
@@ -26,6 +26,9 @@ cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 cc_test(
     name = "emboss_test_util_test",

--- a/runtime/cpp/BUILD
+++ b/runtime/cpp/BUILD
@@ -37,6 +37,9 @@ filegroup(
     ],
     visibility = ["//:__subpackages__"],
 )
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 cc_library(
     name = "cpp_utils",

--- a/runtime/cpp/test/BUILD
+++ b/runtime/cpp/test/BUILD
@@ -19,6 +19,9 @@ load(
     ":build_defs.bzl",
     "emboss_cc_util_test",
 )
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 emboss_cc_util_test(
     name = "emboss_prelude_test",

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -22,6 +22,7 @@ load(
 )
 
 package(
+    default_applicable_licenses = ["//:license"],
     default_visibility = ["//:__subpackages__"],
 )
 

--- a/testdata/golden_cpp/BUILD
+++ b/testdata/golden_cpp/BUILD
@@ -1,3 +1,6 @@
+package(
+    default_applicable_licenses = ["//:license"],
+)
 # Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR adds missing `default_applicable_licenses` to BUILD files to satisfy Buildifier and internal compliance linting.