### PR TITLE
Fix BUILD file formatting and action mnemonics

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,7 +16,6 @@ load("@pip//:requirements.bzl", "requirement")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
-load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 package(
     default_applicable_licenses = ["//:license"],

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -114,6 +114,7 @@ def _emboss_library_impl(ctx):
         outputs = [out],
         arguments = [src.path, "--output-file=" + out.path] + imports + imports_arg,
         executable = ctx.executable._emboss_compiler,
+        mnemonic = "Emboss",
     )
     transitive_sources = depset(
         direct = [src],
@@ -193,6 +194,7 @@ def _cc_emboss_aspect_impl(target, ctx):
         arguments = [args],
         inputs = emboss_info.direct_ir,
         outputs = headers,
+        mnemonic = "EmbossCc",
     )
     runtime_cc_info = ctx.attr._emboss_cc_runtime[CcInfo]
     transitive_headers = depset(

--- a/compiler/back_end/cpp/BUILD
+++ b/compiler/back_end/cpp/BUILD
@@ -24,7 +24,6 @@ package(
     default_visibility = [
         "//visibility:private",
     ],
-    features = ["-layering_check"],
 )
 
 py_binary(

--- a/compiler/back_end/cpp/generated_code_templates
+++ b/compiler/back_end/cpp/generated_code_templates
@@ -407,6 +407,8 @@ ${inner_scope_definitions}
       if (!emboss_reserved_switch_discrim.Known()) return false;
       switch (emboss_reserved_switch_discrim.ValueOrDefault()) {
 ${switch_cases}
+        
+        default: break;
       }
     }
 

--- a/integration/googletest/BUILD
+++ b/integration/googletest/BUILD
@@ -15,6 +15,10 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
 cc_library(
     name = "emboss_test_util",
     testonly = 1,
@@ -25,9 +29,6 @@ cc_library(
         "@com_google_absl//absl/memory",
         "@com_google_googletest//:gtest",
     ],
-)
-package(
-    default_applicable_licenses = ["//:license"],
 )
 
 cc_test(

--- a/runtime/cpp/BUILD
+++ b/runtime/cpp/BUILD
@@ -16,6 +16,10 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
 filegroup(
     name = "raw_headers",
     srcs = [
@@ -36,9 +40,6 @@ filegroup(
         "emboss_view_parameters.h",
     ],
     visibility = ["//:__subpackages__"],
-)
-package(
-    default_applicable_licenses = ["//:license"],
 )
 
 cc_library(

--- a/runtime/cpp/test/BUILD
+++ b/runtime/cpp/test/BUILD
@@ -19,6 +19,7 @@ load(
     ":build_defs.bzl",
     "emboss_cc_util_test",
 )
+
 package(
     default_applicable_licenses = ["//:license"],
 )

--- a/testdata/golden_cpp/condition.emb.h
+++ b/testdata/golden_cpp/condition.emb.h
@@ -387,6 +387,8 @@ class GenericBasicConditionalView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -1459,6 +1461,8 @@ class GenericConditionalAndUnconditionalOverlappingFinalFieldView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -2047,6 +2051,8 @@ class GenericConditionalBasicConditionalFieldFirstView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -2562,6 +2568,8 @@ class GenericConditionalAndDynamicLocationView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -3184,6 +3192,8 @@ class GenericConditionUsesMinIntView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -3729,6 +3739,8 @@ class GenericNestedConditionalView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -3744,6 +3756,8 @@ class GenericNestedConditionalView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -4367,6 +4381,8 @@ class GenericCorrectNestedConditionalView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -6857,6 +6873,8 @@ class GenericConditionDoesNotContributeToSizeView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -7533,6 +7551,8 @@ class GenericEnumConditionView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -13346,6 +13366,8 @@ class GenericChoiceConditionView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -15019,6 +15041,8 @@ class GenericContainsContainsBitsView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -16722,6 +16746,8 @@ class GenericConditionalInlineView final {
 
 
 
+        
+        default: break;
       }
     }
 
@@ -17350,6 +17376,8 @@ class GenericEmbossReservedAnonymousField2View final {
 
 
 
+        
+        default: break;
       }
     }
 

--- a/testdata/golden_cpp/many_conditionals.emb.h
+++ b/testdata/golden_cpp/many_conditionals.emb.h
@@ -812,6 +812,8 @@ class GenericLargeConditionalsView final {
 
 
 
+        
+        default: break;
       }
     }
 

--- a/testdata/golden_cpp/parameters.emb.h
+++ b/testdata/golden_cpp/parameters.emb.h
@@ -421,6 +421,8 @@ if (!parameters_initialized_) return false;
 
 
 
+        
+        default: break;
       }
     }
 
@@ -3396,6 +3398,8 @@ if (!parameters_initialized_) return false;
 
 
 
+        
+        default: break;
       }
     }
 

--- a/testdata/golden_cpp/virtual_field.emb.h
+++ b/testdata/golden_cpp/virtual_field.emb.h
@@ -9611,6 +9611,8 @@ class GenericVirtualUnconditionallyUsesConditionalView final {
 
 
 
+        
+        default: break;
       }
     }
 


### PR DESCRIPTION
This PR moves `package()` declarations to the top of `BUILD` files to satisfy Bazel formatting rules, removes an obsolete `features` flag, and adds missing mnemonics to Starlark actions.