### PR TITLE
Add generated-Ok() code-size + execution-speed benchmark harness

### DIFF
--- a/.github/workflows/code-size.yml
+++ b/.github/workflows/code-size.yml
@@ -1,0 +1,175 @@
+name: Code size
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Only run when something that can change generated code size moves.
+    paths:
+      - 'compiler/**'
+      - 'runtime/**'
+      - 'embossc'
+      - 'testdata/benchmark.emb'
+      - 'testdata/many_conditionals.emb'
+      - 'scripts/size_bench.py'
+      - 'scripts/size_comment.py'
+      - 'scripts/emboss_insncount.c'
+      - 'scripts/build_qemu_plugin.sh'
+      - '.github/workflows/code-size.yml'
+
+# Read the PR's commits; post/update one sticky size comment.
+permissions:
+  contents: read
+  pull-requests: write
+
+# Supersede an in-flight size run when the PR is pushed again.
+concurrency:
+  group: code-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  size-report:
+    name: Generated code size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head (full history for merge-base + revision checkouts)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      # embossc formats generated headers with clang-format (the clang-format
+      # PyPI package, pinned in requirements.txt), so the codegen run needs the
+      # Emboss Python deps. setup-python avoids the runner's externally-managed
+      # system Python (PEP 668).
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install Emboss Python deps (clang-format for codegen)
+        run: pip install -r requirements.txt
+
+      - name: Install compilers and speed-benchmark build deps
+        # clang + arm-none-eabi (Cortex-M4 size); arm-linux-gnueabihf + qemu build
+        # deps power the opt-in execution-speed run (see the qemu step below).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang gcc-arm-none-eabi \
+            g++-arm-linux-gnueabihf \
+            meson ninja-build pkg-config libglib2.0-dev
+
+      # embedded code-size targets compile against the MicroBlaze gcc toolchain
+      # hard-coded under /opt/microblaze/...; cache the Bootlin tarball in a
+      # runner-writable path (caching /opt fights root perms on restore), then
+      # extract it into place. clang has no MicroBlaze back end, so MicroBlaze is
+      # gcc-only.
+      - name: Cache MicroBlaze (Bootlin) toolchain tarball
+        uses: actions/cache@v4
+        with:
+          path: ~/mb-toolchain/mb.tar.xz
+          key: bootlin-microblazebe--glibc--stable-2025.08-1
+      - name: Provision MicroBlaze toolchain
+        run: |
+          set -euo pipefail
+          url="https://toolchains.bootlin.com/downloads/releases/toolchains/microblazebe/tarballs/microblazebe--glibc--stable-2025.08-1.tar.xz"
+          if [ ! -f "$HOME/mb-toolchain/mb.tar.xz" ]; then
+            mkdir -p "$HOME/mb-toolchain"
+            curl -fsSL "$url" -o "$HOME/mb-toolchain/mb.tar.xz"
+          fi
+          sudo mkdir -p /opt/microblaze
+          sudo tar -C /opt/microblaze -xJf "$HOME/mb-toolchain/mb.tar.xz"
+          test -x /opt/microblaze/microblazebe--glibc--stable-2025.08-1/bin/microblaze-buildroot-linux-gnu-g++
+
+      # Little-endian MicroBlaze. The *authoritative* LE size target is the
+      # AMD/Xilinx Vitis toolchain, but that is proprietary and locally-licensed,
+      # so it can't run in public CI -- size_bench.py's have() skips it here. The
+      # open-source Bootlin microblazeel build is the CI LE proxy (and provides
+      # the LE speed binary below); locally, both are measured.
+      - name: Cache MicroBlaze LE (Bootlin) toolchain tarball
+        uses: actions/cache@v4
+        with:
+          path: ~/mb-toolchain/mbel.tar.xz
+          key: bootlin-microblazeel--glibc--stable-2025.08-1
+      - name: Provision MicroBlaze LE toolchain
+        run: |
+          set -euo pipefail
+          url="https://toolchains.bootlin.com/downloads/releases/toolchains/microblazeel/tarballs/microblazeel--glibc--stable-2025.08-1.tar.xz"
+          if [ ! -f "$HOME/mb-toolchain/mbel.tar.xz" ]; then
+            mkdir -p "$HOME/mb-toolchain"
+            curl -fsSL "$url" -o "$HOME/mb-toolchain/mbel.tar.xz"
+          fi
+          sudo mkdir -p /opt/microblaze
+          sudo tar -C /opt/microblaze -xJf "$HOME/mb-toolchain/mbel.tar.xz"
+          test -x /opt/microblaze/microblazeel--glibc--stable-2025.08-1/bin/microblazeel-buildroot-linux-gnu-g++
+
+      # Execution-speed metric (retired-instruction count) needs a plugin-enabled
+      # qemu-user, which the distro build is not -- so build a minimal one from
+      # source (cached; ~a few minutes on a cache miss, seconds otherwise). This
+      # is best-effort: if it fails, the speed run degrades to host wall-clock and
+      # the size report is unaffected.
+      - name: Cache plugin-enabled qemu build
+        uses: actions/cache@v4
+        with:
+          path: ~/emboss-qemu
+          key: emboss-qemu-10.0.11-${{ hashFiles('scripts/emboss_insncount.c', 'scripts/build_qemu_plugin.sh') }}
+      - name: Build plugin-enabled qemu + instruction-count plugin
+        continue-on-error: true
+        run: |
+          if [ ! -x "$HOME/emboss-qemu/qemu-build/qemu-microblazeel" ]; then
+            scripts/build_qemu_plugin.sh 10.0.11 "$HOME/emboss-qemu"
+          fi
+
+      - name: Measure generated code size (merge-base vs PR head)
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Baseline against the merge-base, NOT the base-branch tip, so codegen
+          # that landed on the base after this PR branched is not misattributed.
+          # size_bench.py holds the benchmark schema fixed (pulled forward from
+          # head), so only the generator/runtime under test differs.
+          base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "Comparing merge-base $base  ->  head $HEAD_SHA"
+          # Wire the plugin-enabled qemu for retired-instruction counts when the
+          # build above succeeded; otherwise --speed degrades to wall-clock only.
+          if [ -x "$HOME/emboss-qemu/qemu-build/qemu-microblazeel" ] \
+             && [ -f "$HOME/emboss-qemu/emboss_insncount.so" ]; then
+            export EMBOSS_QEMU_DIR="$HOME/emboss-qemu/qemu-build"
+            export EMBOSS_QEMU_PLUGIN="$HOME/emboss-qemu/emboss_insncount.so"
+          fi
+          python3 scripts/size_bench.py --revisions "$base" "$HEAD_SHA" --speed --out-dir "$RUNNER_TEMP/size"
+          # Fail loudly rather than post an empty table if the head build produced
+          # no data (missing toolchain/dep or a codegen break).
+          python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); h=d["revisions"][-1]["results"]; sys.exit(0 if any(cfg.get("benchmark") for t in h.values() for c in t.values() for cfg in c.values()) else 1)' "$RUNNER_TEMP/size/size_bench.json" \
+            || { echo "::error::size_bench produced no head benchmark data (toolchain/codegen failure); see output above."; exit 1; }
+          python3 scripts/size_comment.py "$RUNNER_TEMP/size/size_bench.json" > "$RUNNER_TEMP/size/comment.md"
+
+      - name: Post / update size comment
+        # Fork PRs get a read-only GITHUB_TOKEN; same-repo PRs (the chain branches)
+        # can comment. (Fork-safe upgrade: a separate workflow_run job.)
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/size/comment.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- emboss-size-bench -->';
+            let body;
+            try {
+              body = fs.readFileSync(process.env.COMMENT_PATH, 'utf8');
+            } catch (e) {
+              return;  // measure step failed; its red check is the signal.
+            }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/scripts/build_qemu_plugin.sh
+++ b/scripts/build_qemu_plugin.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds what `size_bench.py --speed` needs for deterministic retired-instruction
+# counts: a plugin-enabled qemu-user (arm + microblaze + microblazeel) and the
+# instruction-counter TCG plugin (scripts/emboss_insncount.c). The distro
+# qemu-user is built without --enable-plugins, so a from-source qemu is required.
+#
+# Usage:
+#   scripts/build_qemu_plugin.sh [QEMU_VERSION] [DEST_DIR]
+# then point the harness at the results:
+#   export EMBOSS_QEMU_DIR=<DEST_DIR>/qemu-build
+#   export EMBOSS_QEMU_PLUGIN=<DEST_DIR>/emboss_insncount.so
+#   python3 scripts/size_bench.py --speed --out-dir out
+#
+# Build deps (Debian/Ubuntu): meson ninja-build pkg-config libglib2.0-dev python3.
+# Speed toolchains (used by size_bench.py, not by this script): the Bootlin
+# microblaze[el] gcc and g++-arm-linux-gnueabihf. The distro qemu-user package is
+# not needed -- the from-source binaries built here are invoked directly.
+set -euo pipefail
+
+QEMU_VERSION="${1:-10.0.11}"
+DEST="${2:-$HOME/emboss-qemu}"
+SCRIPTS="$(cd "$(dirname "$0")" && pwd)"
+
+mkdir -p "$DEST"
+cd "$DEST"
+
+TARBALL="qemu-${QEMU_VERSION}.tar.xz"
+[ -f "$TARBALL" ] || curl -fsSL "https://download.qemu.org/${TARBALL}" -o "$TARBALL"
+[ -d "qemu-${QEMU_VERSION}" ] || tar -xf "$TARBALL"
+
+echo "Configuring qemu-user (arm, microblaze, microblazeel) with plugins..."
+rm -rf qemu-build && mkdir qemu-build && cd qemu-build
+"../qemu-${QEMU_VERSION}/configure" \
+  --target-list=arm-linux-user,microblaze-linux-user,microblazeel-linux-user \
+  --enable-plugins --disable-system --disable-tools --disable-docs \
+  --disable-werror --disable-debug-info
+ninja qemu-arm qemu-microblaze qemu-microblazeel
+cd ..
+
+echo "Building the instruction-counter plugin..."
+gcc -O2 -shared -fPIC \
+  -I"qemu-${QEMU_VERSION}/include/qemu" $(pkg-config --cflags glib-2.0) \
+  -o "$DEST/emboss_insncount.so" "$SCRIPTS/emboss_insncount.c"
+
+cat <<EOF
+
+Built:
+  qemu:   $DEST/qemu-build/{qemu-arm,qemu-microblaze,qemu-microblazeel}
+  plugin: $DEST/emboss_insncount.so
+
+Now run the speed benchmark with:
+  export EMBOSS_QEMU_DIR=$DEST/qemu-build
+  export EMBOSS_QEMU_PLUGIN=$DEST/emboss_insncount.so
+  python3 scripts/size_bench.py --speed --out-dir out
+EOF

--- a/scripts/emboss_insncount.c
+++ b/scripts/emboss_insncount.c
@@ -1,0 +1,63 @@
+/* Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Minimal QEMU TCG plugin used by size_bench.py --speed: counts retired guest
+ * instructions and prints the total to stderr at exit as `insns: <N>`. The count
+ * is deterministic for a given (binary, guest arch), which makes it a stable
+ * cross-architecture execution-speed metric where wall-clock is not.
+ *
+ * It uses an inline per-vCPU add (no per-instruction callback), so emulation runs
+ * at near-native qemu speed even for billions of instructions.
+ *
+ * Built against the QEMU 10.x plugin API (version 4). QEMU's own contrib/plugins
+ * no longer ships an instruction counter (libinsn was dropped), hence this local
+ * plugin. Build it with scripts/build_qemu_plugin.sh.
+ */
+
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <glib.h>
+#include <qemu-plugin.h>
+
+QEMU_PLUGIN_EXPORT int qemu_plugin_version = QEMU_PLUGIN_VERSION;
+
+static struct qemu_plugin_scoreboard *score;
+static qemu_plugin_u64 insn_count;
+
+static void vcpu_tb_trans(qemu_plugin_id_t id, struct qemu_plugin_tb *tb) {
+  size_t n = qemu_plugin_tb_n_insns(tb);
+  for (size_t i = 0; i < n; i++) {
+    struct qemu_plugin_insn *insn = qemu_plugin_tb_get_insn(tb, i);
+    qemu_plugin_register_vcpu_insn_exec_inline_per_vcpu(
+        insn, QEMU_PLUGIN_INLINE_ADD_U64, insn_count, 1);
+  }
+}
+
+static void plugin_exit(qemu_plugin_id_t id, void *p) {
+  fprintf(stderr, "insns: %" PRIu64 "\n", qemu_plugin_u64_sum(insn_count));
+}
+
+QEMU_PLUGIN_EXPORT int qemu_plugin_install(qemu_plugin_id_t id,
+                                           const qemu_info_t *info, int argc,
+                                           char **argv) {
+  score = qemu_plugin_scoreboard_new(sizeof(uint64_t));
+  insn_count = qemu_plugin_scoreboard_u64(score);
+  qemu_plugin_register_vcpu_tb_trans_cb(id, vcpu_tb_trans);
+  qemu_plugin_register_atexit_cb(id, plugin_exit, NULL);
+  return 0;
+}

--- a/scripts/size_bench.py
+++ b/scripts/size_bench.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Measures the size and instruction count of Emboss-generated code.
+
+Compiles a fixed benchmark schema (testdata/benchmark.emb) plus the
+many_conditionals Ok() highlight across a matrix of target x compiler x
+optimization level, reporting `.text` bytes and static instruction counts
+(from objdump disassembly -- a deterministic stand-in for a runtime benchmark).
+
+With --revisions BASE HEAD, each revision is measured with the benchmark schema
+held fixed (pulled forward from HEAD), so only the code generator under test
+varies between them. Results, including which compiler/version produced each
+number, are written as JSON.
+
+  python3 scripts/size_bench.py --revisions <base-sha> <head-sha> --out-dir out
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Common flags: C++17, per-function/data sections (so `size`/objdump are
+# comparable), and no exceptions/RTTI to match typical embedded builds.
+COMMON_FLAGS = (
+    "-std=c++17 -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti"
+)
+CONFIGS = {"Os": "-Os", "O2": "-O2", "O0": "-O0"}
+
+# MicroBlaze big-endian (the toolchain the landed #257 numbers were measured on)
+# and little-endian, both from Bootlin.
+_MB_BE = "/opt/microblaze/microblazebe--glibc--stable-2025.08-1/bin/microblaze-buildroot-linux-gnu"
+_MB_LE = "/opt/microblaze/microblazeel--glibc--stable-2025.08-1/bin/microblazeel-buildroot-linux-gnu"
+
+# AMD/Xilinx Vitis MicroBlaze little-endian toolchain: the actually-shipped
+# target, so authoritative for LE size. It is proprietary and locally-licensed,
+# so it is never present in public CI -- have() skips it there, and the
+# open-source Bootlin microblazeel build stands in as the CI little-endian proxy
+# (its `.text`/Ok() numbers track BE closely; Vitis is the number that ships).
+_VITIS = "/usr/local/google/edatools/xilinx/2025.2/Vitis"
+_VITIS_MB = _VITIS + "/gnu/microblaze/lin/bin/mb"
+_VITIS_ENV = {"LD_LIBRARY_PATH": _VITIS + "/lib/lnx64.o/Ubuntu/24"}
+_VITIS_FLAGS = (
+    "-mcpu=v11.0 -mlittle-endian -mxl-barrel-shift -mxl-pattern-compare "
+    "-mno-xl-soft-mul -mno-xl-soft-div"
+)
+
+# Measurement matrix. clang has no MicroBlaze back end and needs extra wiring to
+# find the bare-metal ARM C++ headers, so clang is x86-64-only here; cross
+# targets use their gcc toolchains. Host binutils `size`/`nm`/`objdump` read the
+# x86-64 objects for both gcc and clang; cross targets use their own binutils.
+# A compiler may carry an "env" dict (extra process env, e.g. Vitis'
+# LD_LIBRARY_PATH) applied to every compiler/binutils invocation for it.
+TARGETS = [
+    {
+        "target": "x86-64",
+        "compilers": [
+            {
+                "name": "gcc",
+                "cxx": "g++",
+                "nm": "nm",
+                "objdump": "objdump",
+                "flags": "",
+            },
+            {
+                "name": "clang",
+                "cxx": "clang++",
+                "nm": "nm",
+                "objdump": "objdump",
+                "flags": "",
+            },
+        ],
+    },
+    {
+        "target": "ARM Cortex-M4",
+        "compilers": [
+            {
+                "name": "gcc",
+                "cxx": "arm-none-eabi-g++",
+                "nm": "arm-none-eabi-nm",
+                "objdump": "arm-none-eabi-objdump",
+                "flags": "-mthumb -mcpu=cortex-m4 -mfloat-abi=soft",
+            },
+        ],
+    },
+    {
+        "target": "MicroBlaze BE",
+        "compilers": [
+            {
+                "name": "gcc",
+                "cxx": f"{_MB_BE}-g++",
+                "nm": f"{_MB_BE}-nm",
+                "objdump": f"{_MB_BE}-objdump",
+                "flags": "",
+            },
+        ],
+    },
+    {
+        # Authoritative little-endian size (the shipped target). Local-only.
+        "target": "MicroBlaze LE (Vitis)",
+        "compilers": [
+            {
+                "name": "gcc",
+                "cxx": f"{_VITIS_MB}-g++",
+                "nm": f"{_VITIS_MB}-nm",
+                "objdump": f"{_VITIS_MB}-objdump",
+                "flags": _VITIS_FLAGS,
+                "env": _VITIS_ENV,
+            },
+        ],
+    },
+    {
+        # Open-source little-endian proxy (available in CI where Vitis is not).
+        "target": "MicroBlaze LE (Bootlin)",
+        "compilers": [
+            {
+                "name": "gcc",
+                "cxx": f"{_MB_LE}-g++",
+                "nm": f"{_MB_LE}-nm",
+                "objdump": f"{_MB_LE}-objdump",
+                "flags": "",
+            },
+        ],
+    },
+]
+
+# Schema inputs held fixed across revisions so only the generator varies.
+PULL_FORWARD = ["testdata/benchmark.emb", "testdata/many_conditionals.emb"]
+
+# Driver over benchmark.emb: one fn per top-level view, each exercising Ok()
+# (validate/read) and CopyFrom() (read source + write dest). Compiled, never
+# run, so field values / conditional activeness don't matter -- only emitted
+# code. Keep the view list in sync with testdata/benchmark.emb.
+BENCHMARK_VIEWS = ["Scalars", "Bitfields", "Repeated", "Conditional", "Nested"]
+BENCHMARK_DRIVER = (
+    "#include <cstddef>\n#include <cstdint>\n\n"
+    '#include "testdata/benchmark.emb.h"\n\n'
+    "namespace { volatile ::std::uint64_t g_sink; }\n\n"
+    "#define BENCH(NAME, MAKER) \\\n"
+    '  extern "C" void bench_##NAME(char *a, char *b, ::std::size_t n) { \\\n'
+    "    auto va = ::emboss::benchmark::MAKER(a, n); \\\n"
+    "    auto vb = ::emboss::benchmark::MAKER(b, n); \\\n"
+    "    g_sink ^= static_cast<::std::uint64_t>(va.Ok()); \\\n"
+    "    va.CopyFrom(vb); \\\n"
+    "  }\n\n" + "".join(f"BENCH({v}, Make{v}View)\n" for v in BENCHMARK_VIEWS)
+)
+
+# Highlight driver: forces the optimized many_conditionals Ok() methods to be
+# emitted. Both LargeConditionals (single-equality switch) and
+# DisjunctionConditionals (||-coalesced switch) are measured -- the two shapes
+# optimize differently, so both are load-bearing.
+MANYCOND_DRIVER = (
+    "#include <cstdint>\n\n"
+    '#include "testdata/many_conditionals.emb.h"\n\n'
+    "volatile bool emboss_result_sink;\n"
+    'extern "C" void large_ok(const char *buf) {\n'
+    "  auto v = ::emboss::test::MakeLargeConditionalsView(buf, 100);\n"
+    "  emboss_result_sink = v.Ok();\n"
+    "}\n"
+    'extern "C" void disjunction_ok(const char *buf) {\n'
+    "  auto v = ::emboss::test::MakeDisjunctionConditionalsView(buf, 16);\n"
+    "  emboss_result_sink = v.Ok();\n"
+    "}\n"
+)
+MANYCOND_OK_SYMBOL = r"GenericLargeConditionalsView<.*>::Ok\(\) const$"
+MANYCOND_DISJ_OK_SYMBOL = r"GenericDisjunctionConditionalsView<.*>::Ok\(\) const$"
+
+# Four TUs exercising distinct instantiations of the optimized Ok(), consumed by
+# the later optimization phases:
+#   reader_only    -- a read-only View Ok() (the shipped hot path)
+#   both           -- read-only View Ok() + read-write Writer Ok()/CopyFrom()
+#   writer_only    -- read-write Writer Ok()/CopyFrom() only (Lever B watches this
+#                     for a regression when Ok() is deduped onto the reader)
+#   residual_heavy -- a residual-guarded schema; stubbed on DisjunctionConditionals
+#                     until Phase 2 adds an OuterGuardedUnion schema
+# Read-only storage demangles as ContiguousBuffer<char const, ...>; read-write as
+# ContiguousBuffer<char, ...>. ok_symbols() splits the two on that `const`.
+_OK_HDR = (
+    "#include <cstdint>\n\n"
+    '#include "testdata/many_conditionals.emb.h"\n\n'
+    "volatile bool emboss_ok_sink;\n\n"
+)
+_LARGE_READER = (
+    'extern "C" void reader_ok(const char *buf) {\n'
+    "  emboss_ok_sink = ::emboss::test::MakeLargeConditionalsView(buf, 100).Ok();\n"
+    "}\n"
+)
+_LARGE_WRITER = (
+    'extern "C" void writer_ok(char *a, char *b) {\n'
+    "  auto va = ::emboss::test::MakeLargeConditionalsView(a, 100);\n"
+    "  emboss_ok_sink = va.Ok();\n"
+    "  va.CopyFrom(::emboss::test::MakeLargeConditionalsView(b, 100));\n"
+    "}\n"
+)
+OK_DRIVERS = {
+    "reader_only": _OK_HDR + _LARGE_READER,
+    "both": _OK_HDR + _LARGE_READER + _LARGE_WRITER,
+    "writer_only": _OK_HDR + _LARGE_WRITER,
+    "residual_heavy": _OK_HDR
+    + (
+        'extern "C" void residual_ok(const char *buf) {\n'
+        "  emboss_ok_sink = "
+        "::emboss::test::MakeDisjunctionConditionalsView(buf, 16).Ok();\n"
+        "}\n"
+    ),
+}
+# The struct whose Ok() each driver instantiates (for symbol classification).
+OK_DRIVER_STRUCT = {
+    "reader_only": "LargeConditionals",
+    "both": "LargeConditionals",
+    "writer_only": "LargeConditionals",
+    "residual_heavy": "DisjunctionConditionals",
+}
+
+# ---- execution speed (opt-in via --speed) --------------------------------------
+#
+# Speed needs a *runnable* binary, so it uses linux-userspace toolchains (glibc)
+# whose output runs under qemu-user -- distinct from the bare-metal size targets
+# (arm-none-eabi, Vitis mb-elf), which can't. Two numbers per target:
+#   * retired-instruction count -- deterministic, from qemu-user + the bundled
+#     TCG plugin (scripts/emboss_insncount.c). This is the primary speed metric.
+#   * host wall-clock seconds -- a real-time number, only meaningful natively
+#     (x86); recorded for cross targets too but is emulated (qemu) time.
+# Plugin-enabled qemu is not the distro build, so its location and the plugin
+# .so are taken from env; when absent, retired-insn is skipped and only
+# wall-clock (host) / static insn-count (all targets) remain -- the documented
+# fallback. See scripts/build_qemu_plugin.sh.
+SPEED_FLAGS = "-std=c++17 -Os -fno-exceptions -fno-rtti"
+SPEED_ITERS = 5000  # x100 tags = 500k reader Ok() calls; loop dominates startup.
+SPEED_TARGETS = [
+    {"target": "x86-64", "cxx": "g++", "static": False, "qemu": None},
+    {
+        "target": "ARM (armhf)",
+        "cxx": "arm-linux-gnueabihf-g++",
+        "static": True,
+        "qemu": "qemu-arm",
+    },
+    {
+        "target": "MicroBlaze BE",
+        "cxx": f"{_MB_BE}-g++",
+        "static": True,
+        "qemu": "qemu-microblaze",
+    },
+    {
+        "target": "MicroBlaze LE",
+        "cxx": f"{_MB_LE}-g++",
+        "static": True,
+        "qemu": "qemu-microblazeel",
+    },
+]
+# Reader Ok() hot loop: a writer sets the tag, the read-only view validates. Both
+# views alias one buffer, so the loop's work is dominated by the reader Ok().
+SPEED_DRIVER = (
+    "#include <chrono>\n#include <cstdint>\n#include <cstdio>\n\n"
+    '#include "testdata/many_conditionals.emb.h"\n\n'
+    "#ifndef EMBOSS_SPEED_ITERS\n#define EMBOSS_SPEED_ITERS 5000\n#endif\n\n"
+    "int main() {\n"
+    "  char buf[128] = {0};\n"
+    "  auto w = ::emboss::test::MakeLargeConditionalsView(buf, 100);\n"
+    "  const char *cbuf = buf;\n"
+    "  auto r = ::emboss::test::MakeLargeConditionalsView(cbuf, 100);\n"
+    "  volatile bool sink = false;\n"
+    "  auto t0 = ::std::chrono::steady_clock::now();\n"
+    "  for (int i = 0; i < EMBOSS_SPEED_ITERS; ++i)\n"
+    "    for (int tag = 0; tag < 100; ++tag) {\n"
+    "      w.tag().Write(tag);\n"
+    "      sink = r.Ok();\n"
+    "    }\n"
+    "  auto t1 = ::std::chrono::steady_clock::now();\n"
+    '  ::std::printf("wallclock_s=%.6f\\n",\n'
+    "                ::std::chrono::duration<double>(t1 - t0).count());\n"
+    "  (void)sink;\n"
+    "  return 0;\n"
+    "}\n"
+)
+
+
+def run(args, **kw):
+    """Runs a command, returning stripped stdout; raises on non-zero exit."""
+    return subprocess.run(
+        args, cwd=kw.pop("cwd", REPO), capture_output=True, text=True, check=True, **kw
+    ).stdout.strip()
+
+
+def have(compiler):
+    """True if the compiler's executable is available."""
+    cxx = compiler["cxx"]
+    return bool(shutil.which(cxx) or (os.path.isabs(cxx) and os.path.exists(cxx)))
+
+
+def compiler_env(compiler):
+    """Process env for invoking `compiler` (and its binutils), or None.
+
+    Some toolchains need extra environment -- e.g. Vitis' mb-g++/mb-nm need
+    LD_LIBRARY_PATH to find their shared libs. Returns a full env dict (os.environ
+    plus the override) when the compiler declares one, else None.
+    """
+    extra = compiler.get("env")
+    if not extra:
+        return None
+    env = dict(os.environ)
+    env.update(extra)
+    return env
+
+
+def embossc(emb, out_include_dir):
+    """Generates the C++ header for `emb` under out_include_dir/testdata/."""
+    out = os.path.join(out_include_dir, "testdata")
+    os.makedirs(out, exist_ok=True)
+    name = os.path.basename(emb) + ".h"
+    run(
+        [
+            os.path.join(REPO, "embossc"),
+            "--import-dir=.",
+            "--import-dir=testdata",
+            "--output-file=" + name,
+            "--output-path=" + out,
+            os.path.join("testdata", os.path.basename(emb)),
+        ]
+    )
+
+
+def text_bytes(obj):
+    """`.text` size of an object file, via host binutils `size`."""
+    out = run(["size", obj])
+    return int(out.splitlines()[1].split()[0])
+
+
+def insn_count(objdump, obj, env=None):
+    """Static instruction count: disassembly lines that begin with an address."""
+    out = subprocess.run(
+        [objdump, "-d", obj], cwd=REPO, capture_output=True, text=True, env=env
+    ).stdout
+    return sum(1 for ln in out.splitlines() if re.match(r"\s+[0-9a-f]+:", ln))
+
+
+def symbol_bytes(nm, obj, pattern, env=None):
+    """Size in bytes of the last symbol matching `pattern` (nm --size-sort -S)."""
+    out = subprocess.run(
+        [nm, "--size-sort", "-S", "--demangle", obj],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout
+    matches = [ln for ln in out.splitlines() if re.search(pattern, ln)]
+    if not matches:
+        return None
+    return int(matches[-1].split()[1], 16)
+
+
+def ok_symbols(nm, obj, struct, env=None):
+    """Reader/writer Ok() sizes for Generic<struct>View, as {'reader','writer'}.
+
+    Read-only storage demangles as ContiguousBuffer<char const, ...> and
+    read-write as ContiguousBuffer<char, ...>; the `const` in the storage arg
+    (before `>::Ok`) tells them apart. Either value is None when its
+    instantiation isn't present in the object.
+    """
+    pattern = rf"Generic{struct}View<.*>::Ok\(\) const$"
+    out = subprocess.run(
+        [nm, "--size-sort", "-S", "--demangle", obj],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout
+    reader = writer = None
+    for ln in out.splitlines():
+        if not re.search(pattern, ln):
+            continue
+        size = int(ln.split()[1], 16)
+        storage = ln.split(">::Ok")[0]  # exclude the trailing `Ok() const`
+        if "const" in storage:
+            reader = size if reader is None else max(reader, size)
+        else:
+            writer = size if writer is None else max(writer, size)
+    return {"reader": reader, "writer": writer}
+
+
+def compile_obj(compiler, flags, driver_path, include_dir, obj):
+    """Compiles a driver TU; returns True on success."""
+    cmd = (
+        [compiler["cxx"]]
+        + COMMON_FLAGS.split()
+        + flags.split()
+        + compiler["flags"].split()
+        + ["-I" + REPO, "-I" + include_dir, "-c", driver_path, "-o", obj]
+    )
+    return (
+        subprocess.run(
+            cmd, cwd=REPO, capture_output=True, text=True, env=compiler_env(compiler)
+        ).returncode
+        == 0
+    )
+
+
+def _qemu_bin(name):
+    """Resolve a plugin-enabled qemu-user binary: EMBOSS_QEMU_DIR first (a build
+    with --enable-plugins), else PATH (the distro build, which usually can't load
+    plugins -- only wall-clock works there)."""
+    qdir = os.environ.get("EMBOSS_QEMU_DIR")
+    if qdir:
+        p = os.path.join(qdir, name)
+        return p if os.path.exists(p) else None
+    return shutil.which(name)
+
+
+def measure_speed(work, include_dir):
+    """Per runnable target: native/emulated wall-clock and (under a plugin-enabled
+    qemu) a deterministic retired-instruction count. Returns {target: {...}}."""
+    drv = os.path.join(work, "speed_driver.cc")
+    with open(drv, "w") as f:
+        f.write(SPEED_DRIVER)
+    plugin = os.environ.get("EMBOSS_QEMU_PLUGIN")
+    have_plugin = bool(plugin and os.path.exists(plugin))
+    out = {}
+    for st in SPEED_TARGETS:
+        cxx = st["cxx"]
+        if not (shutil.which(cxx) or os.path.exists(cxx)):
+            continue
+        exe = os.path.join(work, "speed_" + st["target"].replace(" ", "_"))
+        cmd = (
+            [cxx]
+            + SPEED_FLAGS.split()
+            + [f"-DEMBOSS_SPEED_ITERS={SPEED_ITERS}"]
+            + (["-static"] if st["static"] else [])
+            + ["-I" + REPO, "-I" + include_dir, drv, "-o", exe]
+        )
+        if subprocess.run(cmd, cwd=REPO, capture_output=True, text=True).returncode:
+            continue
+        cell = {"iters": SPEED_ITERS, "wallclock_s": None, "retired_insns": None}
+        if st["qemu"] is None:
+            # Host: native wall-clock is the real-time signal; best of a few runs.
+            times = []
+            for _ in range(3):
+                r = subprocess.run([exe], cwd=REPO, capture_output=True, text=True)
+                m = re.search(r"wallclock_s=([\d.]+)", r.stdout)
+                if m:
+                    times.append(float(m.group(1)))
+            if times:
+                cell["wallclock_s"] = min(times)
+        else:
+            # Cross target: retired-instruction count is the deterministic metric
+            # (wall-clock under qemu measures emulation, not the target -- skipped).
+            qemu = _qemu_bin(st["qemu"])
+            if qemu and have_plugin:
+                r = subprocess.run(
+                    [qemu, "-plugin", plugin, exe],
+                    cwd=REPO,
+                    capture_output=True,
+                    text=True,
+                )
+                m = re.search(r"insns:\s*(\d+)", r.stderr)
+                if m:
+                    cell["retired_insns"] = int(m.group(1))
+        out[st["target"]] = cell
+    return out
+
+
+def measure_current(work, with_speed=False):
+    """Measures the currently checked-out tree across the whole matrix."""
+    include_dir = os.path.join(work, "include")
+    os.makedirs(include_dir, exist_ok=True)
+
+    # Generate headers with the revision's own embossc (the generator under
+    # test). A revision that can't generate the fixed schema is reported as
+    # missing rather than skewing a total.
+    have_bench = have_manycond = True
+    try:
+        embossc("benchmark.emb", include_dir)
+    except subprocess.CalledProcessError:
+        have_bench = False
+    try:
+        embossc("many_conditionals.emb", include_dir)
+    except subprocess.CalledProcessError:
+        have_manycond = False
+
+    bench_drv = os.path.join(work, "benchmark_driver.cc")
+    manycond_drv = os.path.join(work, "manycond_driver.cc")
+    with open(bench_drv, "w") as f:
+        f.write(BENCHMARK_DRIVER)
+    with open(manycond_drv, "w") as f:
+        f.write(MANYCOND_DRIVER)
+    ok_drv = {}
+    for dname, dsrc in OK_DRIVERS.items():
+        p = os.path.join(work, f"ok_{dname}_driver.cc")
+        with open(p, "w") as f:
+            f.write(dsrc)
+        ok_drv[dname] = p
+
+    versions = {}
+    results = {}
+    for entry in TARGETS:
+        target = entry["target"]
+        results[target] = {}
+        for compiler in entry["compilers"]:
+            if not have(compiler):
+                continue
+            cname = compiler["name"]
+            cenv = compiler_env(compiler)
+            objdump = compiler["objdump"]
+            nm = compiler["nm"]
+            try:
+                versions[f"{target}/{cname}"] = run(
+                    [compiler["cxx"], "--version"], env=cenv
+                ).splitlines()[0]
+            except Exception:  # noqa: BLE001
+                versions[f"{target}/{cname}"] = "?"
+            results[target][cname] = {}
+            for cfg, cfg_flag in CONFIGS.items():
+                cell = {}
+                if have_bench:
+                    obj = os.path.join(work, f"bench_{target}_{cname}_{cfg}.o")
+                    if compile_obj(compiler, cfg_flag, bench_drv, include_dir, obj):
+                        cell["benchmark"] = {
+                            "text": text_bytes(obj),
+                            "insns": insn_count(objdump, obj, cenv),
+                        }
+                if have_manycond:
+                    obj = os.path.join(work, f"mc_{target}_{cname}_{cfg}.o")
+                    if compile_obj(compiler, cfg_flag, manycond_drv, include_dir, obj):
+                        cell["many_conditionals_ok"] = {
+                            "text": symbol_bytes(nm, obj, MANYCOND_OK_SYMBOL, cenv),
+                            "disj_text": symbol_bytes(
+                                nm, obj, MANYCOND_DISJ_OK_SYMBOL, cenv
+                            ),
+                            "insns": insn_count(objdump, obj, cenv),
+                        }
+                    # Per-instantiation Ok() drivers for the later phases.
+                    drivers = {}
+                    for dname, dpath in ok_drv.items():
+                        dobj = os.path.join(
+                            work, f"ok_{dname}_{target}_{cname}_{cfg}.o"
+                        )
+                        if compile_obj(compiler, cfg_flag, dpath, include_dir, dobj):
+                            syms = ok_symbols(nm, dobj, OK_DRIVER_STRUCT[dname], cenv)
+                            drivers[dname] = {
+                                "text": text_bytes(dobj),
+                                "insns": insn_count(objdump, dobj, cenv),
+                                "reader_ok": syms["reader"],
+                                "writer_ok": syms["writer"],
+                            }
+                    if drivers:
+                        cell["ok_drivers"] = drivers
+                results[target][cname][cfg] = cell
+    out = {"compiler_versions": versions, "results": results}
+    if with_speed:
+        out["speed"] = measure_speed(work, include_dir)
+    return out
+
+
+# ---- git revision driving (hold the schema fixed; vary only the generator) ----
+
+
+def current_ref():
+    r = subprocess.run(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip() if r.returncode == 0 else run(["git", "rev-parse", "HEAD"])
+
+
+def measure_revision(rev, original_ref, work_root, with_speed=False):
+    sha = run(["git", "rev-parse", rev])
+    run(["git", "checkout", sha])
+    # Pull the fixed schema forward from the starting ref so the only thing that
+    # differs between revisions is the generator (and runtime) under test.
+    for path in PULL_FORWARD:
+        subprocess.run(
+            ["git", "checkout", original_ref, "--", path], cwd=REPO, capture_output=True
+        )
+    try:
+        work = tempfile.mkdtemp(dir=work_root)
+        return {"sha": sha, **measure_current(work, with_speed=with_speed)}
+    finally:
+        run(["git", "reset", "--hard"])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--revisions",
+        nargs="+",
+        default=["HEAD"],
+        help="Revisions to measure; with two, the first is the base for deltas.",
+    )
+    parser.add_argument("--out-dir", default="size_results")
+    parser.add_argument(
+        "--speed",
+        action="store_true",
+        help="Also measure execution speed (wall-clock + qemu retired-insns). "
+        "Needs the linux-user toolchains; retired-insns need a plugin-enabled "
+        "qemu via EMBOSS_QEMU_DIR + EMBOSS_QEMU_PLUGIN (see build_qemu_plugin.sh).",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    work_root = tempfile.mkdtemp(dir=args.out_dir)
+
+    out = {"revisions": []}
+    if args.revisions == ["HEAD"]:
+        # Single-shot: measure the working tree as-is (no checkout dance).
+        out["revisions"].append(
+            {
+                "sha": run(["git", "rev-parse", "HEAD"]),
+                **measure_current(
+                    tempfile.mkdtemp(dir=work_root), with_speed=args.speed
+                ),
+            }
+        )
+    else:
+        if subprocess.run(
+            ["git", "status", "--porcelain"], cwd=REPO, capture_output=True, text=True
+        ).stdout.strip():
+            print(
+                "error: working tree is dirty; commit or stash first.", file=sys.stderr
+            )
+            return 1
+        original = current_ref()
+        try:
+            for rev in args.revisions:
+                print(f"Measuring {rev}...", file=sys.stderr)
+                out["revisions"].append(
+                    measure_revision(rev, original, work_root, with_speed=args.speed)
+                )
+        finally:
+            run(["git", "checkout", original])
+            run(["git", "reset", "--hard"])
+
+    if len(out["revisions"]) >= 2:
+        out["base"] = out["revisions"][0]["sha"]
+        out["head"] = out["revisions"][-1]["sha"]
+
+    path = os.path.join(args.out_dir, "size_bench.json")
+    with open(path, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"Wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/size_bench.py
+++ b/scripts/size_bench.py
@@ -157,7 +157,7 @@ BENCHMARK_DRIVER = (
     '#include "testdata/benchmark.emb.h"\n\n'
     "namespace { volatile ::std::uint64_t g_sink; }\n\n"
     "#define BENCH(NAME, MAKER) \\\n"
-    '  extern "C" void bench_##NAME(char *a, char *b, ::std::size_t n) { \\\n'
+    '  extern "C" void bench_##NAME(unsigned char *a, unsigned char *b, ::std::size_t n) { \\\n'
     "    auto va = ::emboss::benchmark::MAKER(a, n); \\\n"
     "    auto vb = ::emboss::benchmark::MAKER(b, n); \\\n"
     "    g_sink ^= static_cast<::std::uint64_t>(va.Ok()); \\\n"
@@ -173,11 +173,11 @@ MANYCOND_DRIVER = (
     "#include <cstdint>\n\n"
     '#include "testdata/many_conditionals.emb.h"\n\n'
     "volatile bool emboss_result_sink;\n"
-    'extern "C" void large_ok(const char *buf) {\n'
+    'extern "C" void large_ok(const unsigned char *buf) {\n'
     "  auto v = ::emboss::test::MakeLargeConditionalsView(buf, 100);\n"
     "  emboss_result_sink = v.Ok();\n"
     "}\n"
-    'extern "C" void disjunction_ok(const char *buf) {\n'
+    'extern "C" void disjunction_ok(const unsigned char *buf) {\n'
     "  auto v = ::emboss::test::MakeDisjunctionConditionalsView(buf, 16);\n"
     "  emboss_result_sink = v.Ok();\n"
     "}\n"
@@ -201,12 +201,12 @@ _OK_HDR = (
     "volatile bool emboss_ok_sink;\n\n"
 )
 _LARGE_READER = (
-    'extern "C" void reader_ok(const char *buf) {\n'
+    'extern "C" void reader_ok(const unsigned char *buf) {\n'
     "  emboss_ok_sink = ::emboss::test::MakeLargeConditionalsView(buf, 100).Ok();\n"
     "}\n"
 )
 _LARGE_WRITER = (
-    'extern "C" void writer_ok(char *a, char *b) {\n'
+    'extern "C" void writer_ok(unsigned char *a, unsigned char *b) {\n'
     "  auto va = ::emboss::test::MakeLargeConditionalsView(a, 100);\n"
     "  emboss_ok_sink = va.Ok();\n"
     "  va.CopyFrom(::emboss::test::MakeLargeConditionalsView(b, 100));\n"
@@ -218,9 +218,9 @@ OK_DRIVERS = {
     "writer_only": _OK_HDR + _LARGE_WRITER,
     "residual_heavy": _OK_HDR
     + (
-        'extern "C" void residual_ok(const char *buf) {\n'
+        'extern "C" void residual_ok(const unsigned char *buf) {\n'
         "  emboss_ok_sink = "
-        "::emboss::test::MakeDisjunctionConditionalsView(buf, 16).Ok();\n"
+        "::emboss::test::MakeOuterGuardedUnionView(buf, 12).Ok();\n"
         "}\n"
     ),
 }
@@ -229,7 +229,7 @@ OK_DRIVER_STRUCT = {
     "reader_only": "LargeConditionals",
     "both": "LargeConditionals",
     "writer_only": "LargeConditionals",
-    "residual_heavy": "DisjunctionConditionals",
+    "residual_heavy": "OuterGuardedUnion",
 }
 
 # ---- execution speed (opt-in via --speed) --------------------------------------
@@ -275,10 +275,11 @@ SPEED_DRIVER = (
     '#include "testdata/many_conditionals.emb.h"\n\n'
     "#ifndef EMBOSS_SPEED_ITERS\n#define EMBOSS_SPEED_ITERS 5000\n#endif\n\n"
     "int main() {\n"
-    "  char buf[128] = {0};\n"
-    "  auto w = ::emboss::test::MakeLargeConditionalsView(buf, 100);\n"
-    "  const char *cbuf = buf;\n"
-    "  auto r = ::emboss::test::MakeLargeConditionalsView(cbuf, 100);\n"
+    "  unsigned char buf[128] = {0};\n"
+    "  auto w = ::emboss::test::MakeOuterGuardedUnionView(buf, 12);\n"
+    "  w.outer().Write(1);\n"
+    "  const unsigned char *cbuf = buf;\n"
+    "  auto r = ::emboss::test::MakeOuterGuardedUnionView(cbuf, 12);\n"
     "  volatile bool sink = false;\n"
     "  auto t0 = ::std::chrono::steady_clock::now();\n"
     "  for (int i = 0; i < EMBOSS_SPEED_ITERS; ++i)\n"

--- a/scripts/size_comment.py
+++ b/scripts/size_comment.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Renders a Markdown PR comment from size_bench.py JSON (base vs head)."""
+
+import json
+import re
+import sys
+
+MARKER = "<!-- emboss-size-bench -->"
+
+
+def short_ver(v):
+    """Pull an X.Y[.Z] version number out of a compiler --version line."""
+    # Compilers print the real version last (after any distro/buildroot tag).
+    matches = re.findall(r"\d+\.\d+(?:\.\d+)?", v or "")
+    return matches[-1] if matches else "?"
+
+
+CONFIGS = ["Os", "O2", "O0"]
+
+
+def cell(rev, target, compiler, config):
+    return (rev["results"].get(target, {}).get(compiler, {}) or {}).get(
+        config, {}
+    ) or {}
+
+
+def delta(base_v, head_v, unit=""):
+    """'1234 B  🟢−5' style cell: head value + colored delta (smaller is better).
+
+    Handles both integer metrics (bytes, instructions) and float metrics
+    (wall-clock seconds).
+    """
+    if head_v is None:
+        return "—"
+    flt = isinstance(head_v, float) or isinstance(base_v, float)
+    s = f"{head_v:.4f}{unit}" if flt else f"{head_v}{unit}"
+    if base_v is None:
+        return s
+    d = head_v - base_v
+    if d == 0:
+        return s
+    pct = f"{d / base_v * 100:+.1f}%" if base_v else ""
+    dstr = f"{d:+.4f}" if flt else f"{d:+d}"
+    icon = "🟢" if d < 0 else "🔴"
+    return f"{s}  {icon}{dstr} ({pct})"
+
+
+def rows(base, head):
+    """Ordered (target, compiler) pairs present in head."""
+    out = []
+    for target in head["results"]:
+        for compiler in head["results"][target]:
+            out.append((target, compiler))
+    return out
+
+
+def table(base, head, config):
+    lines = [
+        "| Target · Compiler | Code size | Instructions "
+        "| `Large Ok()` | `Disj Ok()` |",
+        "|---|--:|--:|--:|--:|",
+    ]
+    for target, compiler in rows(base, head):
+        b = cell(base, target, compiler, config)
+        h = cell(head, target, compiler, config)
+        bb, hb = b.get("benchmark", {}), h.get("benchmark", {})
+        bm, hm = b.get("many_conditionals_ok", {}), h.get("many_conditionals_ok", {})
+        lines.append(
+            f"| {target} · {compiler} "
+            f"| {delta(bb.get('text'), hb.get('text'), ' B')} "
+            f"| {delta(bb.get('insns'), hb.get('insns'))} "
+            f"| {delta(bm.get('text'), hm.get('text'), ' B')} "
+            f"| {delta(bm.get('disj_text'), hm.get('disj_text'), ' B')} |"
+        )
+    return "\n".join(lines)
+
+
+def speed_table(base, head):
+    """Execution-speed table (present only when a --speed run produced data)."""
+    hs = head.get("speed") or {}
+    if not hs:
+        return None
+    bs = base.get("speed") or {}
+    lines = [
+        "| Target | Retired instructions | Wall-clock |",
+        "|---|--:|--:|",
+    ]
+    for target, h in hs.items():
+        b = bs.get(target, {}) or {}
+        lines.append(
+            f"| {target} "
+            f"| {delta(b.get('retired_insns'), h.get('retired_insns'))} "
+            f"| {delta(b.get('wallclock_s'), h.get('wallclock_s'), ' s')} |"
+        )
+    return "\n".join(lines)
+
+
+def verdict(base, head):
+    """Headline focused on `.text` (size) regressions, with a worst-case call-out."""
+    worst = None  # (delta_bytes, pct, label)
+    improved = 0
+    for target, compiler in rows(base, head):
+        for config in CONFIGS:
+            b = cell(base, target, compiler, config)
+            h = cell(head, target, compiler, config)
+            for key, label in (
+                ("benchmark", "bench .text"),
+                ("many_conditionals_ok", "Ok()"),
+            ):
+                bv = (b.get(key) or {}).get("text")
+                hv = (h.get(key) or {}).get("text")
+                if bv is None or hv is None:
+                    continue
+                if hv > bv:
+                    pct = (hv - bv) / bv * 100 if bv else 0.0
+                    if worst is None or (hv - bv) > worst[0]:
+                        worst = (hv - bv, pct, f"{target} {compiler} {label} -{config}")
+                elif hv < bv:
+                    improved += 1
+    if worst:
+        d, pct, lbl = worst
+        return f"⚠️ largest size regression +{d} B ({pct:+.1f}%) on {lbl}"
+    if improved:
+        return f"🟢 smaller in {improved} place(s), none larger"
+    return "✅ no change"
+
+
+def render(data):
+    revs = data.get("revisions", [])
+    if len(revs) < 2:
+        return MARKER + "\n_Need a base and head revision to compare._"
+    base, head = revs[0], revs[-1]
+    versions = " · ".join(
+        f"{k.replace('/', ' ')} {short_ver(v)}"
+        for k, v in head.get("compiler_versions", {}).items()
+    )
+
+    out = [
+        MARKER,
+        "### 📐 Generated code size & instructions",
+        f"`{base['sha'][:9]} → {head['sha'][:9]}` · smaller is better · **{verdict(base, head)}**",
+        "",
+        "<sub>**Code size** (compiled `.text` bytes) and **Instructions** (objdump count) are totals "
+        "for the generated code of the all-features `benchmark.emb` fixture. **`Large Ok()`** / "
+        "**`Disj Ok()`** are the sizes (bytes) of the optimized `LargeConditionals` and "
+        "`DisjunctionConditionals` validation methods, highlights. "
+        "Δ vs the merge-base · 🟢 smaller / 🔴 larger.</sub>",
+        "",
+        "#### `-Os` (embedded)",
+        table(base, head, "Os"),
+        "",
+    ]
+    speed = speed_table(base, head)
+    if speed:
+        out += [
+            "#### Execution speed",
+            "<sub>Deterministic retired-instruction count under qemu-user "
+            "(cross targets) and native wall-clock (host), for a fixed reader "
+            "`Ok()` loop. Smaller is faster.</sub>",
+            "",
+            speed,
+            "",
+        ]
+    out += [
+        "<details><summary><code>-O2</code> / <code>-O0</code></summary>",
+        "",
+        "**`-O2`**",
+        table(base, head, "O2"),
+        "",
+        "**`-O0`**",
+        table(base, head, "O0"),
+        "",
+        "</details>",
+        "",
+        f"<sub>Compilers: {versions}. `benchmark.emb` is a fixed fixture (Ok()+CopyFrom over every "
+        "top-level view); it is pulled forward from head, so only the code generator under test "
+        "varies between base and head.</sub>",
+    ]
+    return "\n".join(out)
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "size_results/size_bench.json"
+    with open(path) as f:
+        print(render(json.load(f)))
+
+
+if __name__ == "__main__":
+    main()

--- a/testdata/benchmark.emb
+++ b/testdata/benchmark.emb
@@ -1,0 +1,132 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+-- FIXED BENCHMARK FIXTURE -- avoid editing.
+--
+-- This schema exists solely to measure the *size* and *instruction count* of
+-- the code Emboss generates, across a deliberately broad slice of language
+-- features. It is NOT a correctness test and is held fixed so the numbers stay
+-- comparable over time: a change here moves the measured baseline. Only edit it
+-- to cover a genuinely new language feature, accepting that the numbers shift.
+--
+-- The benchmark driver instantiates each parameter-free top-level struct
+-- (Scalars, Bitfields, Repeated, Conditional, Nested) and exercises Ok(),
+-- Equals() (read-all) and CopyFrom() (read-all + write-all).
+
+[$default byte_order: "LittleEndian"]
+[(cpp) namespace: "emboss::benchmark"]
+
+
+enum Shape:
+  CIRCLE   = 0
+  SQUARE   = 1
+  TRIANGLE = 2
+  HEXAGON  = 7
+
+
+enum WideId:
+  [maximum_bits: 64]
+  LOW  = 0
+  HIGH = 0x7fff_ffff_ffff_ffff
+
+
+bits PackedFlags:
+  7 [+1]  Flag  alpha
+  6 [+1]  Flag  beta
+  2 [+4]  UInt  nibble
+  0 [+2]  UInt  pair
+
+
+struct Point:
+  0 [+2]  UInt  x
+  2 [+2]  UInt  y
+
+
+struct Scaled(scale: UInt:8):
+  0 [+4]  UInt  raw
+    [requires: this < 1000000]
+  let scaled = raw * scale
+
+
+# Scalar coverage: integer widths, signedness, an arbitrary byte width, an
+# opposite-endianness field, an enum, two floats, $next, and virtual fields.
+struct Scalars:
+  0     [+1]  UInt    u8
+  1     [+2]  UInt    u16
+  3     [+4]  UInt    u32
+  7     [+8]  UInt    u64
+  15    [+4]  Int     s32
+  19    [+3]  UInt    u24
+  22    [+4]  UInt    be32
+    [byte_order: "BigEndian"]
+  26    [+1]  Shape   shape
+  27    [+8]  WideId  wide
+  35    [+4]  Float   f32
+  39    [+8]  Float   f64
+  $next [+1]  UInt    trailer
+  let u32_doubled = u32 * 2
+  let u16_plus_u8 = u16 + u8
+
+
+# Bitfields: a named bits type, an inline anonymous bits block, and an inline
+# anonymous enum inside it.
+struct Bitfields:
+  0 [+1]  PackedFlags  flags
+  1 [+4]  bits:
+    31 [+1]  Flag  top
+    14 [+4]  enum  mode:
+      IDLE = 0
+      RUN  = 1
+    0  [+9]  UInt  low9
+  5 [+1]  UInt  tail
+
+
+# Arrays: fixed byte array, sub-byte-element array, array of structs, and a
+# dynamically-sized trailing array.
+struct Repeated:
+  0  [+1]      UInt:8      count
+  1  [+8]      UInt:8[8]   fixed_bytes
+  9  [+4]      UInt:16[2]  words
+  13 [+8]      Point[2]    points
+  21 [+count]  UInt:8[]    variable
+  let total = count + 8
+
+
+# Conditionals: a run of single-tag `if`s (switch-coalesced by the optimizer),
+# a disjunction, and a range conjunction.
+struct Conditional:
+  0 [+4]  UInt  tag
+  if tag == 0:
+    4 [+4]  UInt  a0
+  if tag == 1:
+    4 [+4]  UInt  a1
+  if tag == 2:
+    4 [+4]  UInt  a2
+  if tag == 3:
+    4 [+4]  UInt  a3
+  if tag == 4:
+    4 [+4]  UInt  a4
+  if tag == 10 || tag == 11 || tag == 12 || tag == 13:
+    4 [+4]  UInt  grouped
+  if tag >= 100 && tag <= 200:
+    8 [+4]  UInt  ranged
+
+
+# Nesting + parameter passing + a [requires] constraint.
+struct Nested:
+  0  [+1]  UInt       factor
+  1  [+4]  Scaled(2)  doubled
+  5  [+4]  Scaled(4)  quadrupled
+  9  [+4]  Point      origin
+  13 [+8]  Point[2]   corners


### PR DESCRIPTION
## What

Adds a committed, CI-integrated harness for measuring the **static code size** and
**execution speed** of Emboss-generated C++ `Ok()` validation code across the
embedded targets the ongoing `Ok()`/switch codegen work cares about.

- `scripts/size_bench.py` — compiles a fixed benchmark schema (`testdata/benchmark.emb`)
  plus the `many_conditionals` `Ok()` highlight across a target × compiler × opt-level
  matrix, reporting per-TU `.text` (`size`) and per-symbol `Ok()` size (`nm -S`, nested-`>`
  demangle regex). `--revisions BASE HEAD` holds the schema fixed (pulled forward from
  head) so only the generator/runtime under test varies; `--speed` adds a dynamic run.
- `scripts/size_comment.py` — renders the JSON into a sticky Markdown PR comment.
- `.github/workflows/code-size.yml` — provisions the toolchains, baselines against the
  **merge-base** (not the base tip, so codegen that lands on the base after a PR branches
  isn't misattributed), and posts/updates one sticky size comment per PR.
- `scripts/emboss_insncount.c` + `scripts/build_qemu_plugin.sh` — a plugin-enabled
  qemu-user build + TCG plugin for the deterministic retired-instruction speed metric.

## Targets

- **ARM Cortex-M4 / Thumb-2** (`arm-none-eabi-g++`, size) + `arm-linux-gnueabihf` (speed).
- **MicroBlaze big-endian** (Bootlin `microblazebe`).
- **MicroBlaze little-endian** — the shipped config. The *authoritative* size target is
  AMD/Xilinx **Vitis 2025.2 LE v11.0** (`mb-g++`), which is proprietary and
  locally-licensed, so `have()` skips it in public CI; the open-source Bootlin
  `microblazeel` build is the CI LE proxy and provides the LE speed binary.
- **x86-64** (`g++`/`clang++`) as a reference.

## Speed metric

Deterministic guest **retired-instruction count** under a plugin-enabled qemu-user (both
MicroBlaze endiannesses + ARM), plus host wall-clock on x86. The distro qemu-user has no
plugin support and qemu 10 dropped `contrib/plugins/libinsn.c`, so the harness builds
qemu 10.0.11 `--enable-plugins` and ships its own instruction-count plugin; when absent,
the speed run degrades to wall-clock and the size report is unaffected.

## Checkpoint 0 baseline (verified against master)

`LargeConditionals::Ok()` reader symbol @ `-Os`:

| Target | `Ok()` bytes |
|---|---|
| x86-64 (g++) | 3048 |
| ARM Cortex-M4 | 4628 |
| MicroBlaze BE | 7704 |
| MicroBlaze LE (Vitis, authoritative) | 8156 |

Speed @ `-Os`, retired instructions: ARM 9.32B · MB-BE 12.75B · MB-LE 12.17B; x86 host
wall-clock 0.42 s.

## Supersedes

Replaces the earlier code-size tooling PRs, folding their coverage into one CI-integrated
harness:

- **#252** (`embedded_bench.sh`/`embedded_compare.sh`) — its dual-`Ok()`-symbol coverage
  (`LargeConditionals` + `DisjunctionConditionals`) is preserved here.
- **#265** (`embedded_bench.sh` rewrite) — superseded by `size_bench.py`.
- **#267** (`profile_tool.py` PR-comment workflow, stacked on #265) — superseded by
  `size_comment.py` + `code-size.yml`.

New here beyond all three: MicroBlaze **LE** (Vitis authoritative + Bootlin proxy), the
dynamic **execution-speed** metric, and four per-instantiation `Ok()` driver TUs
(reader-only / both / writer-only / residual-heavy) consumed by the follow-on
optimization PRs.
