### PR TITLE
Propagate an `undefined` value for possibly-zero `//`/`%` divisors

### DIFF
--- a/compiler/back_end/cpp/header_generator.py
+++ b/compiler/back_end/cpp/header_generator.py
@@ -836,8 +836,16 @@ def _render_expression(expression, ir, field_reader=None, subexpressions=None):
     # will fit into C++ types, or that operator arguments and return types can fit
     # in the same type: expressions like `-0x8000_0000_0000_0000` and
     # `0x1_0000_0000_0000_0000 - 1` can appear.
+    # A value that can be undefined must not be folded to a compile-time literal,
+    # even when its *defined* range collapses to a single value (modulus ==
+    # "infinity" / a fixed boolean): at runtime it may be Unknown (e.g. a
+    # division by zero), which only the real Maybe<>-returning computation can
+    # represent.
     if expression.type.which_type == "integer":
-        if expression.type.integer.modulus == "infinity":
+        if (
+            expression.type.integer.modulus == "infinity"
+            and not expression.type.integer.can_be_undefined
+        ):
             return _ExpressionResult(
                 _render_integer_for_expression(
                     int(expression.type.integer.modular_value)
@@ -845,7 +853,10 @@ def _render_expression(expression, ir, field_reader=None, subexpressions=None):
                 True,
             )
     elif expression.type.which_type == "boolean":
-        if expression.type.boolean.has_field("value"):
+        if (
+            expression.type.boolean.has_field("value")
+            and not expression.type.boolean.can_be_undefined
+        ):
             if expression.type.boolean.value:
                 return _ExpressionResult(_maybe_type("bool") + "(true)", True)
             else:
@@ -1415,9 +1426,15 @@ def _is_discriminant_provably_known(discrim_expr, fields):
         if ir_util.field_is_virtual(f):
             return False
         cond = f.existence_condition
+        # An existence condition that can be undefined is not provably known at
+        # runtime, so the Known() guard on the discriminant read must be kept.
+        # (In practice the boolean folder never sets `value` on a
+        # can-be-undefined condition, so this is belt-and-suspenders; it keeps
+        # the elision sound regardless of how folding evolves.)
         return (
             cond.type.which_type == "boolean"
             and cond.type.boolean.has_field("value")
+            and not cond.type.boolean.can_be_undefined
             and bool(cond.type.boolean.value)
         )
     return False

--- a/compiler/back_end/cpp/testcode/division_modulus_test.cc
+++ b/compiler/back_end/cpp/testcode/division_modulus_test.cc
@@ -89,6 +89,77 @@ TEST(ChunkedPayload, RoundsUpToMultipleOfFour) {
   EXPECT_EQ(8U, view.padded().ElementCount());
 }
 
+// A field whose size uses a `//` with a possibly-zero divisor works normally
+// when the divisor is nonzero.
+TEST(PayloadSizedByDivision, NonzeroDivisor) {
+  static constexpr ::std::array</**/ ::std::uint8_t, 5> kBuf = {{
+      0x04,                          // divisor = 4 -> 16 // 4 = 4 payload bytes
+      0xaa, 0xbb, 0xcc, 0xdd,        // payload
+  }};
+  auto view = MakePayloadSizedByDivisionView(&kBuf);
+  ASSERT_TRUE(view.Ok());
+  EXPECT_EQ(5U, view.SizeInBytes());
+  EXPECT_EQ(4U, view.payload().ElementCount());
+}
+
+// When the divisor is zero the payload size is undefined, so the structure's
+// size is unknown and Ok() is false -- with no division-by-zero UB.
+TEST(PayloadSizedByDivision, ZeroDivisorIsNotOk) {
+  static constexpr ::std::array</**/ ::std::uint8_t, 5> kBuf = {{
+      0x00,                          // divisor = 0 -> 16 // 0 undefined
+      0xaa, 0xbb, 0xcc, 0xdd,
+  }};
+  auto view = MakePayloadSizedByDivisionView(&kBuf);
+  EXPECT_FALSE(view.Ok());
+  EXPECT_FALSE(view.SizeIsKnown());
+  EXPECT_FALSE(view.IntrinsicSizeInBytes().Ok());
+}
+
+// A field guarded by an existence condition that divides by a field: the
+// condition (and therefore Ok()) is well-defined for nonzero divisors...
+TEST(FieldGatedByDivision, ConditionTrueAndFalse) {
+  // divisor = 4 -> 12 // 4 == 3 -> gated present.
+  static constexpr ::std::array</**/ ::std::uint8_t, 2> kPresent = {{0x04, 0x77}};
+  auto present = MakeFieldGatedByDivisionView(&kPresent);
+  ASSERT_TRUE(present.Ok());
+  EXPECT_TRUE(present.has_gated().ValueOr(false));
+  EXPECT_EQ(0x77U, present.gated().Read());
+
+  // divisor = 5 -> 12 // 5 == 2 != 3 -> gated absent (only 1 byte needed).
+  static constexpr ::std::array</**/ ::std::uint8_t, 1> kAbsent = {{0x05}};
+  auto absent = MakeFieldGatedByDivisionView(&kAbsent);
+  ASSERT_TRUE(absent.Ok());
+  EXPECT_FALSE(absent.has_gated().ValueOr(true));
+}
+
+// ...and is *undefined* for a zero divisor.  The existence condition is Unknown,
+// so the field's presence is unknown and Ok() must return false.  This is the
+// soundness guard for the Ok()/switch discriminant optimization: an undefined
+// existence condition must never be folded to a provably-known value.
+TEST(FieldGatedByDivision, ZeroDivisorIsNotOk) {
+  static constexpr ::std::array</**/ ::std::uint8_t, 2> kBuf = {{0x00, 0x77}};
+  auto view = MakeFieldGatedByDivisionView(&kBuf);
+  EXPECT_FALSE(view.Ok());
+  EXPECT_FALSE(view.has_gated().Known());
+}
+
+// `0 // divisor` collapses to the single value {0}, but must not be folded to a
+// literal: it is undefined when the divisor is zero.
+TEST(CollapsingQuotient, DefinedForNonzeroDivisor) {
+  static constexpr ::std::array</**/ ::std::uint8_t, 1> kBuf = {{0x07}};
+  auto view = MakeCollapsingQuotientView(&kBuf);
+  ASSERT_TRUE(view.Ok());
+  EXPECT_TRUE(view.zero_or_undefined().Ok());
+  EXPECT_EQ(0, view.zero_or_undefined().Read());
+}
+
+TEST(CollapsingQuotient, UndefinedForZeroDivisor) {
+  static constexpr ::std::array</**/ ::std::uint8_t, 1> kBuf = {{0x00}};
+  auto view = MakeCollapsingQuotientView(&kBuf);
+  // The accessor is Unknown -- not a bogus literal 0.
+  EXPECT_FALSE(view.zero_or_undefined().Ok());
+}
+
 }  // namespace
 }  // namespace test
 }  // namespace emboss

--- a/compiler/front_end/constraints.py
+++ b/compiler/front_end/constraints.py
@@ -713,13 +713,15 @@ def _check_bounds_on_runtime_integer_expressions(
 def _check_division_and_modulus_have_nonzero_divisors(
     expression, source_file_name, errors
 ):
-    """Rejects `l // r` and `l % r` whose divisor range could contain zero.
+    """Rejects `l // r` and `l % r` whose divisor is *provably always* zero.
 
-    This is the initial, strict rollout of `//` and `%`: because the expression
-    type system does not yet track an `undefined` value, the only sound option
-    for a divisor whose range includes zero is to reject it at compile time.  A
-    later change will loosen this to allow a *possibly*-zero divisor to propagate
-    an `undefined` value, keeping the error only for a *provably*-zero divisor.
+    A divisor that is provably zero (its range is exactly {0}, e.g. `x // 0`)
+    has no defined result and is rejected at compile time.  A divisor that is
+    merely *possibly* zero (a non-constant range that includes zero, e.g.
+    `x // d` for a byte `d`) is allowed: the expression type system propagates an
+    `undefined` value (tracked by IntegerType.can_be_undefined) and the runtime
+    yields an Unknown result for a `// 0`, so the field's `Ok()` becomes false
+    rather than the whole schema failing to compile.
     """
     if expression.which_expression != "function":
         return
@@ -734,9 +736,10 @@ def _check_division_and_modulus_have_nonzero_divisors(
         return
     rmin = divisor.type.integer.minimum_value
     rmax = divisor.type.integer.maximum_value
-    rmin_le_zero = rmin == "-infinity" or int(rmin) <= 0
-    rmax_ge_zero = rmax == "infinity" or int(rmax) >= 0
-    if rmin_le_zero and rmax_ge_zero:
+    # Provably always zero iff the divisor's range is exactly {0}.  (The bounds
+    # invariant guarantees minimum_value == maximum_value implies the value is a
+    # constant.)
+    if rmin == "0" and rmax == "0":
         op_text = expression.function.function_name.text
         errors.append(
             [
@@ -748,9 +751,7 @@ def _check_division_and_modulus_have_nonzero_divisors(
                 error.note(
                     source_file_name,
                     divisor.source_location,
-                    "Divisor range is {} to {}, which includes zero.".format(
-                        rmin, rmax
-                    ),
+                    "Divisor is always zero.",
                 ),
             ]
         )

--- a/compiler/front_end/constraints_test.py
+++ b/compiler/front_end/constraints_test.py
@@ -80,31 +80,50 @@ class ConstraintsTest(unittest.TestCase):
         )
         self.assertEqual([], constraints.check_constraints(ir))
 
-    def test_error_on_division_with_divisor_range_including_zero(self):
+    def test_no_error_on_division_with_divisor_range_including_zero(self):
+        # A *possibly*-zero divisor is now allowed: it propagates an `undefined`
+        # value (IntegerType.can_be_undefined) and yields an Unknown result at
+        # runtime rather than failing to compile.
         ir = _make_ir_from_emb(
             "struct Foo:\n"
             "  0 [+1]  UInt  divisor\n"
             "  1 [+1]  UInt  dividend\n"
             "  let q = dividend // divisor\n"
         )
-        errors = error.filter_errors(constraints.check_constraints(ir))
-        self.assertEqual(1, len(errors))
-        self.assertIn("Right argument of '//' cannot be zero.", errors[0][0].message)
+        self.assertEqual([], constraints.check_constraints(ir))
 
-    def test_error_on_modulus_with_divisor_range_including_zero(self):
+    def test_no_error_on_modulus_with_divisor_range_including_zero(self):
         ir = _make_ir_from_emb(
             "struct Foo:\n"
             "  0 [+1]  UInt  divisor\n"
             "  1 [+1]  UInt  dividend\n"
             "  let r = dividend % divisor\n"
         )
+        self.assertEqual([], constraints.check_constraints(ir))
+
+    def test_error_on_division_by_zero_literal(self):
+        # A *provably*-always-zero divisor is still a hard compile error.
+        ir = _make_ir_from_emb(
+            "struct Foo:\n" "  0 [+1]  UInt  x\n" "  let q = x // 0\n"
+        )
+        errors = error.filter_errors(constraints.check_constraints(ir))
+        self.assertEqual(1, len(errors))
+        self.assertIn("Right argument of '//' cannot be zero.", errors[0][0].message)
+
+    def test_error_on_modulus_by_zero_literal(self):
+        ir = _make_ir_from_emb(
+            "struct Foo:\n" "  0 [+1]  UInt  x\n" "  let r = x % 0\n"
+        )
         errors = error.filter_errors(constraints.check_constraints(ir))
         self.assertEqual(1, len(errors))
         self.assertIn("Right argument of '%' cannot be zero.", errors[0][0].message)
 
-    def test_error_on_division_by_zero_literal(self):
+    def test_error_on_division_by_provably_zero_expression(self):
+        # A divisor that folds to a constant zero (range exactly {0}) is
+        # provably always zero, so it is rejected even though it is not a bare
+        # `0` literal.
         ir = _make_ir_from_emb(
-            "struct Foo:\n" "  0 [+1]  UInt  x\n" "  let q = x // 0\n"
+            "struct Foo:\n" "  0 [+1]  UInt  x\n" "  let q = x // (3 - 3)\n"
         )
         errors = error.filter_errors(constraints.check_constraints(ir))
         self.assertEqual(1, len(errors))

--- a/compiler/front_end/expression_bounds.py
+++ b/compiler/front_end/expression_bounds.py
@@ -368,6 +368,34 @@ def _min(a):
     return min(int(n) for n in a if not _is_infinite(n))
 
 
+def _range_includes_zero(minimum_value, maximum_value):
+    """Returns True if the closed range [minimum_value, maximum_value] holds 0.
+
+    minimum_value and maximum_value are ints, stringified ints, "-infinity", or
+    "infinity".
+    """
+    min_le_zero = minimum_value == "-infinity" or int(minimum_value) <= 0
+    max_ge_zero = maximum_value == "infinity" or int(maximum_value) >= 0
+    return min_le_zero and max_ge_zero
+
+
+def _any_can_be_undefined(operands):
+    """Returns True if any of the given operand expressions can be undefined."""
+    for operand in operands:
+        operand_type = operand.type
+        if (
+            operand_type.which_type == "integer"
+            and operand_type.integer.can_be_undefined
+        ):
+            return True
+        if (
+            operand_type.which_type == "boolean"
+            and operand_type.boolean.can_be_undefined
+        ):
+            return True
+    return False
+
+
 def _compute_constraints_of_additive_operator(expression):
     """Computes the modular value of an additive expression."""
     funcs = {
@@ -402,6 +430,8 @@ def _compute_constraints_of_additive_operator(expression):
         rmin = right.type.integer.minimum_value
     expression.type.integer.minimum_value = str(func(lmin, rmin))
     expression.type.integer.maximum_value = str(func(lmax, rmax))
+    if _any_can_be_undefined(args):
+        expression.type.integer.can_be_undefined = True
 
 
 def _compute_constraints_of_multiplicative_operator(expression):
@@ -439,6 +469,8 @@ def _compute_constraints_of_multiplicative_operator(expression):
     ]
     expression.type.integer.minimum_value = str(_min(extrema))
     expression.type.integer.maximum_value = str(_max(extrema))
+    if _any_can_be_undefined(expression.function.args):
+        expression.type.integer.can_be_undefined = True
 
     if all(bound.modulus == "infinity" for bound in bounds):
         # If both sides are constant, the result is constant.
@@ -557,6 +589,15 @@ def _compute_constraints_of_division_operator(expression):
     """Computes the bounds of a `//` (flooring integer division) expression."""
     left, right = (arg.type.integer for arg in expression.function.args)
 
+    # `//` introduces undefined-ness: the result can be undefined if either
+    # operand can be undefined, or if the divisor's range includes zero (a
+    # runtime `// 0`).  The constraints pass rejects a *provably*-zero divisor;
+    # a merely *possibly*-zero divisor is allowed and carries this flag.
+    if _any_can_be_undefined(expression.function.args) or _range_includes_zero(
+        right.minimum_value, right.maximum_value
+    ):
+        expression.type.integer.can_be_undefined = True
+
     # Both sides constant: compute the exact result.
     if left.modulus == "infinity" and right.modulus == "infinity":
         r_val = int(right.modular_value)
@@ -609,6 +650,13 @@ def _compute_constraints_of_division_operator(expression):
 def _compute_constraints_of_modulus_operator(expression):
     """Computes the bounds of a `%` (flooring modulus) expression."""
     left, right = (arg.type.integer for arg in expression.function.args)
+
+    # As with `//`, `%` introduces undefined-ness when the divisor's range
+    # includes zero (or an operand is already undefined).
+    if _any_can_be_undefined(expression.function.args) or _range_includes_zero(
+        right.minimum_value, right.maximum_value
+    ):
+        expression.type.integer.can_be_undefined = True
 
     if left.modulus == "infinity" and right.modulus == "infinity":
         r_val = int(right.modular_value)
@@ -693,6 +741,12 @@ def _compute_constant_value_of_comparison_operator(expression):
         expression.type.boolean.value = func(
             *[ir_util.constant_value(arg) for arg in args]
         )
+    # An operand that can be undefined poisons the result.  Note that an operand
+    # that can be undefined is never a compile-time constant (see
+    # ir_util.constant_value), so the branch above never sets a boolean `value`
+    # in that case -- the two are mutually exclusive.
+    if _any_can_be_undefined(args):
+        expression.type.boolean.can_be_undefined = True
 
 
 def _compute_constraints_of_bound_function(expression):
@@ -723,6 +777,8 @@ def _compute_constraints_of_maximum_function(expression):
     expression.type.integer.maximum_value = str(
         _max([arg.type.integer.maximum_value for arg in args])
     )
+    if _any_can_be_undefined(args):
+        expression.type.integer.can_be_undefined = True
     # If the expression is dominated by a constant factor, then the result is
     # constant.  I (bolms@) believe this is the only case where
     # _compute_constraints_of_maximum_function might violate the assertions in
@@ -865,6 +921,17 @@ def _compute_constraints_of_choice_operator(expression):
             "boolean",
             "enumeration",
         ), "Unknown type {} for expression".format(if_true.type.which_type)
+    # The result can be undefined if the condition or the selected branch can be
+    # undefined.  Conservatively, if any of the three operands can be undefined,
+    # the result can be too.  (An `enumeration` result cannot carry the flag, but
+    # a non-constant choice is never treated as a constant enum, so it stays
+    # correctly un-foldable regardless.)
+    if _any_can_be_undefined((condition, if_true, if_false)):
+        # The choice's result type matches if_true's (and if_false's) type.
+        if if_true.type.which_type == "integer":
+            expression.type.integer.can_be_undefined = True
+        elif if_true.type.which_type == "boolean":
+            expression.type.boolean.can_be_undefined = True
 
 
 def _greatest_common_divisor(a, b):

--- a/compiler/front_end/expression_bounds_test.py
+++ b/compiler/front_end/expression_bounds_test.py
@@ -418,6 +418,84 @@ class ComputeConstantsTest(unittest.TestCase):
         self.assertEqual("-3", r.minimum_value)
         self.assertEqual("0", r.maximum_value)
 
+    def test_division_by_maybe_zero_divisor_can_be_undefined(self):
+        # A non-constant divisor whose range includes zero introduces an
+        # undefined value; it does NOT error here (constraints only rejects a
+        # provably-always-zero divisor).
+        ir = self._make_ir(
+            "struct Foo:\n"
+            "  0 [+1]  UInt  d\n"
+            "  1 [+1]  UInt  n\n"
+            "  let q = n // d\n"
+        )
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        self.assertTrue(self._virtual_fields(ir)["q"].can_be_undefined)
+
+    def test_modulus_by_maybe_zero_divisor_can_be_undefined(self):
+        ir = self._make_ir(
+            "struct Foo:\n"
+            "  0 [+1]  UInt  d\n"
+            "  1 [+1]  UInt  n\n"
+            "  let r = n % d\n"
+        )
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        self.assertTrue(self._virtual_fields(ir)["r"].can_be_undefined)
+
+    def test_division_by_nonzero_constant_is_not_undefined(self):
+        ir = self._make_ir(
+            "struct Foo:\n" "  0 [+1]  UInt  x\n" "  let half = x // 2\n"
+        )
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        # None (or False) -- not can_be_undefined.
+        self.assertFalse(self._virtual_fields(ir)["half"].can_be_undefined)
+
+    def test_undefined_propagates_through_arithmetic(self):
+        # `(n // d)` is undefined, so `(n // d) + 1` and `(n // d) * 2` are too.
+        ir = self._make_ir(
+            "struct Foo:\n"
+            "  0 [+1]  UInt  d\n"
+            "  1 [+1]  UInt  n\n"
+            "  let sum = (n // d) + 1\n"
+            "  let product = (n // d) * 2\n"
+        )
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        fields = self._virtual_fields(ir)
+        self.assertTrue(fields["sum"].can_be_undefined)
+        self.assertTrue(fields["product"].can_be_undefined)
+
+    def test_undefined_collapsing_quotient_stays_non_constant(self):
+        # `0 // d` collapses to the single value {0} (modulus == "infinity"),
+        # but can be undefined, so it must not be treated as a constant.
+        ir = self._make_ir("struct Foo:\n" "  0 [+1]  UInt  d\n" "  let z = 0 // d\n")
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        z = self._virtual_fields(ir)["z"]
+        self.assertEqual("infinity", z.modulus)
+        self.assertEqual("0", z.modular_value)
+        self.assertTrue(z.can_be_undefined)
+
+    def test_undefined_propagates_into_boolean_comparison(self):
+        # A comparison against an undefined operand yields an undefined boolean,
+        # and -- crucially -- is NOT folded to a constant boolean `value`, so the
+        # existence condition's Known() guard cannot be elided.
+        ir = self._make_ir(
+            "struct Foo:\n"
+            "  0 [+1]  UInt  d\n"
+            "  if 12 // d == 3:\n"
+            "    1 [+1]  UInt  gated\n"
+        )
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        condition = ir.module[0].type[0].structure.field[1].existence_condition
+        self.assertEqual("boolean", condition.type.which_type)
+        self.assertTrue(condition.type.boolean.can_be_undefined)
+        self.assertFalse(condition.type.boolean.has_field("value"))
+
+    def test_provably_zero_divisor_can_be_undefined(self):
+        # `x // 0` is provably undefined; bounds still computes (constraints
+        # reports the error), and the flag is set.
+        ir = self._make_ir("struct Foo:\n" "  0 [+1]  UInt  x\n" "  let q = x // 0\n")
+        self.assertEqual([], expression_bounds.compute_constants(ir))
+        self.assertTrue(self._virtual_fields(ir)["q"].can_be_undefined)
+
     def test_nested_constant_expression(self):
         ir = self._make_ir(
             "struct Foo:\n" "  if 7*(3+1) == 28:\n" "    0 [+1]  UInt  x\n"

--- a/compiler/util/ir_data.py
+++ b/compiler/util/ir_data.py
@@ -444,10 +444,23 @@ class IntegerType(Message):
     minimum_value: Optional[str] = None
     maximum_value: Optional[str] = None
 
+    # Whether the expression's value can be "undefined" -- that is, whether it
+    # can be the result of a division or modulus by zero.  This is tracked as a
+    # separate boolean flag (never an in-band "undefined" value for
+    # minimum_value/maximum_value/modulus/modular_value) so that the many places
+    # that parse those fields as integers do not have to special-case a sentinel
+    # string.  When can_be_undefined is true, minimum_value/maximum_value/modulus
+    # /modular_value describe the range of the *defined* results; the value may
+    # additionally be undefined at runtime (surfacing as an Unknown Maybe<>).
+    can_be_undefined: Optional[bool] = None
+
 
 @dataclasses.dataclass
 class BooleanType(Message):
     value: Optional[bool] = None
+    # See IntegerType.can_be_undefined.  A boolean expression can be undefined
+    # if it is derived (e.g. via a comparison) from an undefined integer.
+    can_be_undefined: Optional[bool] = None
 
 
 @dataclasses.dataclass

--- a/compiler/util/ir_util.py
+++ b/compiler/util/ir_util.py
@@ -85,6 +85,16 @@ def is_constant(expression, bindings=None):
 def is_constant_type(expression_type):
     """Returns True if expression_type is inhabited by a single value."""
     expression_type = ir_data_utils.reader(expression_type)
+    # A value that can be undefined is not a compile-time constant, even if its
+    # *defined* range collapses to a single value (e.g. `0 // d` for a byte `d`
+    # folds to {0} but is undefined when d == 0).  Treating it as constant would
+    # let codegen emit a bogus literal instead of the real (possibly Unknown)
+    # runtime computation.
+    if (
+        expression_type.integer.can_be_undefined
+        or expression_type.boolean.can_be_undefined
+    ):
+        return False
     return (
         expression_type.integer.modulus == "infinity"
         or expression_type.boolean.has_field("value")
@@ -104,9 +114,15 @@ def constant_value(expression, bindings=None):
         # constant_value is called, the actual values should have been propagated to
         # the type information.
         if expression.type.which_type == "integer":
+            # A value that can be undefined has no single constant value, even
+            # when its defined range collapses to one (modulus == "infinity").
+            if expression.type.integer.can_be_undefined:
+                return None
             assert expression.type.integer.modulus == "infinity"
             return int(expression.type.integer.modular_value)
         elif expression.type.which_type == "boolean":
+            if expression.type.boolean.can_be_undefined:
+                return None
             assert expression.type.boolean.has_field("value")
             return expression.type.boolean.value
         elif expression.type.which_type == "enumeration":

--- a/compiler/util/ir_util_test.py
+++ b/compiler/util/ir_util_test.py
@@ -97,6 +97,52 @@ class IrUtilTest(unittest.TestCase):
             )
         )
 
+    def test_undefined_integer_type_is_not_constant(self):
+        # Even with modulus == "infinity" (a single defined value), a value that
+        # can be undefined is not a compile-time constant.
+        self.assertFalse(
+            ir_util.is_constant_type(
+                ir_data.ExpressionType(
+                    integer=ir_data.IntegerType(
+                        modulus="infinity",
+                        modular_value="0",
+                        minimum_value="0",
+                        maximum_value="0",
+                        can_be_undefined=True,
+                    )
+                )
+            )
+        )
+
+    def test_undefined_boolean_type_is_not_constant(self):
+        self.assertFalse(
+            ir_util.is_constant_type(
+                ir_data.ExpressionType(
+                    boolean=ir_data.BooleanType(value=True, can_be_undefined=True)
+                )
+            )
+        )
+
+    def test_constant_value_of_undefined_reference_is_none(self):
+        # A constant_reference to an integer value that can be undefined has no
+        # single constant value, even when its defined range collapses to one.
+        self.assertIsNone(
+            ir_util.constant_value(
+                ir_data.Expression(
+                    constant_reference=ir_data.Reference(),
+                    type=ir_data.ExpressionType(
+                        integer=ir_data.IntegerType(
+                            modulus="infinity",
+                            modular_value="0",
+                            minimum_value="0",
+                            maximum_value="0",
+                            can_be_undefined=True,
+                        )
+                    ),
+                )
+            )
+        )
+
     def test_is_constant_enumeration_type(self):
         self.assertFalse(
             ir_util.is_constant_type(

--- a/runtime/cpp/emboss_arithmetic.h
+++ b/runtime/cpp/emboss_arithmetic.h
@@ -362,6 +362,42 @@ inline constexpr Maybe<ResultT> Choice(Maybe<ConditionT> condition,
                            : Maybe<ResultT>();
 }
 
+// MaybeDivideOrModulo implements the shared logic for `//` and `%`: like
+// MaybeDo it unwraps Known() operands, casts to IntermediateT, applies
+// OperatorT, and rewraps -- but it is a *special op* (like And/Or/Choice)
+// because Known() operands do not guarantee a Known() result: a zero divisor
+// yields an Unknown result instead.  Returning Unknown (rather than dividing)
+// both avoids C++ undefined behavior on divide-by-zero and lets a runtime
+// `// 0` poison the enclosing expression (e.g. $size_in_bytes -> Ok()) with no
+// crash, matching the Emboss expression type system's `undefined` value.
+template <typename IntermediateT, typename ResultT, typename OperatorT,
+          typename LeftT, typename RightT>
+inline constexpr Maybe<ResultT> MaybeDivideOrModulo(Maybe<LeftT> l,
+                                                    Maybe<RightT> r) {
+  return (!l.Known() || !r.Known() ||
+          static_cast<IntermediateT>(r.ValueOrDefault()) == IntermediateT{0})
+             ? Maybe<ResultT>()
+             : Maybe<ResultT>(static_cast<ResultT>(OperatorT::template Do<>(
+                   static_cast<IntermediateT>(l.ValueOrDefault()),
+                   static_cast<IntermediateT>(r.ValueOrDefault()))));
+}
+
+template <typename IntermediateT, typename ResultT, typename LeftT,
+          typename RightT>
+inline constexpr Maybe<ResultT> FlooringQuotient(Maybe<LeftT> l,
+                                                 Maybe<RightT> r) {
+  return MaybeDivideOrModulo<IntermediateT, ResultT, FlooringQuotientOperation,
+                             LeftT, RightT>(l, r);
+}
+
+template <typename IntermediateT, typename ResultT, typename LeftT,
+          typename RightT>
+inline constexpr Maybe<ResultT> FlooringRemainder(Maybe<LeftT> l,
+                                                  Maybe<RightT> r) {
+  return MaybeDivideOrModulo<IntermediateT, ResultT, FlooringRemainderOperation,
+                             LeftT, RightT>(l, r);
+}
+
 //// From here down: boilerplate instantiations of the various operations, which
 //// only forward to MaybeDo:
 
@@ -382,22 +418,6 @@ template <typename IntermediateT, typename ResultT, typename LeftT,
           typename RightT>
 inline constexpr Maybe<ResultT> Product(Maybe<LeftT> l, Maybe<RightT> r) {
   return MaybeDo<IntermediateT, ResultT, ProductOperation, LeftT, RightT>(l, r);
-}
-
-template <typename IntermediateT, typename ResultT, typename LeftT,
-          typename RightT>
-inline constexpr Maybe<ResultT> FlooringQuotient(Maybe<LeftT> l,
-                                                 Maybe<RightT> r) {
-  return MaybeDo<IntermediateT, ResultT, FlooringQuotientOperation, LeftT,
-                 RightT>(l, r);
-}
-
-template <typename IntermediateT, typename ResultT, typename LeftT,
-          typename RightT>
-inline constexpr Maybe<ResultT> FlooringRemainder(Maybe<LeftT> l,
-                                                  Maybe<RightT> r) {
-  return MaybeDo<IntermediateT, ResultT, FlooringRemainderOperation, LeftT,
-                 RightT>(l, r);
 }
 
 template <typename IntermediateT, typename ResultT, typename LeftT,

--- a/runtime/cpp/test/emboss_arithmetic_test.cc
+++ b/runtime/cpp/test/emboss_arithmetic_test.cc
@@ -161,6 +161,18 @@ TEST(FlooringQuotient, FlooringQuotient) {
       (FlooringQuotient</**/ ::std::int32_t, ::std::int32_t, ::std::int32_t,
                         ::std::int32_t>(Maybe</**/ ::std::int32_t>(),
                                         Maybe</**/ ::std::int32_t>(3))));
+  // A zero divisor yields Unknown even when both operands are Known -- this is
+  // the "undefined" result of `// 0`, avoiding C++ undefined behavior.
+  EXPECT_EQ(
+      Maybe</**/ ::std::int32_t>(),
+      (FlooringQuotient</**/ ::std::int32_t, ::std::int32_t, ::std::int32_t,
+                        ::std::int32_t>(Maybe</**/ ::std::int32_t>(8),
+                                        Maybe</**/ ::std::int32_t>(0))));
+  EXPECT_EQ(Maybe</**/ ::std::uint32_t>(),
+            (FlooringQuotient</**/ ::std::uint32_t, ::std::uint32_t,
+                              ::std::uint32_t, ::std::uint32_t>(
+                Maybe</**/ ::std::uint32_t>(8),
+                Maybe</**/ ::std::uint32_t>(0))));
 }
 
 TEST(FlooringRemainder, FlooringRemainder) {
@@ -200,6 +212,17 @@ TEST(FlooringRemainder, FlooringRemainder) {
       (FlooringRemainder</**/ ::std::int32_t, ::std::int32_t, ::std::int32_t,
                          ::std::int32_t>(Maybe</**/ ::std::int32_t>(8),
                                          Maybe</**/ ::std::int32_t>())));
+  // A zero divisor yields Unknown even when both operands are Known.
+  EXPECT_EQ(
+      Maybe</**/ ::std::int32_t>(),
+      (FlooringRemainder</**/ ::std::int32_t, ::std::int32_t, ::std::int32_t,
+                         ::std::int32_t>(Maybe</**/ ::std::int32_t>(8),
+                                         Maybe</**/ ::std::int32_t>(0))));
+  EXPECT_EQ(Maybe</**/ ::std::uint32_t>(),
+            (FlooringRemainder</**/ ::std::uint32_t, ::std::uint32_t,
+                               ::std::uint32_t, ::std::uint32_t>(
+                Maybe</**/ ::std::uint32_t>(8),
+                Maybe</**/ ::std::uint32_t>(0))));
 }
 
 TEST(Equal, Equal) {

--- a/testdata/division_modulus.emb
+++ b/testdata/division_modulus.emb
@@ -43,3 +43,30 @@ struct Constants:
   let chained_div = 100 // 5 // 2
   let chained_mod = 17 % 7 % 4
   let mixed_divmod = 17 % 7 // 2
+
+
+# A field whose size depends on a runtime `//` with a *possibly*-zero divisor.
+# When divisor == 0 the payload size -- and therefore the whole structure's
+# size -- is undefined, so Ok() is false.  A nonzero divisor works normally.
+struct PayloadSizedByDivision:
+  0 [+1]              UInt      divisor
+  1 [+16 // divisor]  UInt:8[]  payload
+
+
+# A field guarded by an existence condition that involves a possibly-zero
+# divisor.  This exercises the interaction with the Ok()/switch discriminant
+# optimization: when divisor == 0 the condition `12 // divisor == 3` is
+# undefined, so `gated`'s presence is unknown and Ok() must be false.
+struct FieldGatedByDivision:
+  0 [+1]  UInt  divisor
+  if 12 // divisor == 3:
+    1 [+1]  UInt  gated
+
+
+# A virtual field whose `//` result *collapses* to a single defined value ({0})
+# yet can be undefined when the divisor is zero.  Without special handling,
+# codegen would fold it to a bogus literal 0; instead the accessor must return
+# an Unknown result when divisor == 0.
+struct CollapsingQuotient:
+  0 [+1]  UInt  divisor
+  let zero_or_undefined = 0 // divisor

--- a/testdata/golden_cpp/division_modulus.emb.h
+++ b/testdata/golden_cpp/division_modulus.emb.h
@@ -33,6 +33,21 @@ namespace Constants {}  // namespace Constants
 template <class Storage>
 class GenericConstantsView;
 
+namespace PayloadSizedByDivision {}  // namespace PayloadSizedByDivision
+
+template <class Storage>
+class GenericPayloadSizedByDivisionView;
+
+namespace FieldGatedByDivision {}  // namespace FieldGatedByDivision
+
+template <class Storage>
+class GenericFieldGatedByDivisionView;
+
+namespace CollapsingQuotient {}  // namespace CollapsingQuotient
+
+template <class Storage>
+class GenericCollapsingQuotientView;
+
 namespace ArrayOfUint16BySizeInBytes {}  // namespace ArrayOfUint16BySizeInBytes
 
 template <class View>
@@ -2020,6 +2035,1602 @@ MakeAlignedConstantsView(T* emboss_reserved_local_data,
       emboss_reserved_local_data, emboss_reserved_local_size);
 }
 
+namespace PayloadSizedByDivision {}  // namespace PayloadSizedByDivision
+
+template <class View>
+struct EmbossReservedInternalIsGenericPayloadSizedByDivisionView;
+
+template <class Storage>
+class GenericPayloadSizedByDivisionView final {
+ public:
+  GenericPayloadSizedByDivisionView() : backing_() {}
+  explicit GenericPayloadSizedByDivisionView(
+      Storage emboss_reserved_local_bytes)
+      : backing_(emboss_reserved_local_bytes) {}
+
+  template <typename OtherStorage>
+  GenericPayloadSizedByDivisionView(
+      const GenericPayloadSizedByDivisionView<OtherStorage>&
+          emboss_reserved_local_other)
+      : backing_{emboss_reserved_local_other.BackingStorage()} {}
+
+  template <typename Arg,
+            typename = typename ::std::enable_if<
+                !EmbossReservedInternalIsGenericPayloadSizedByDivisionView<
+                    typename ::std::remove_cv<typename ::std::remove_reference<
+                        Arg>::type>::type>::value>::type>
+  explicit GenericPayloadSizedByDivisionView(Arg&& emboss_reserved_local_arg)
+      : backing_(::std::forward<Arg>(emboss_reserved_local_arg)) {}
+  template <typename Arg0, typename Arg1, typename... Args>
+  explicit GenericPayloadSizedByDivisionView(
+      Arg0&& emboss_reserved_local_arg0, Arg1&& emboss_reserved_local_arg1,
+      Args&&... emboss_reserved_local_args)
+      : backing_(::std::forward<Arg0>(emboss_reserved_local_arg0),
+                 ::std::forward<Arg1>(emboss_reserved_local_arg1),
+                 ::std::forward<Args>(emboss_reserved_local_args)...) {}
+
+  template <typename OtherStorage>
+  GenericPayloadSizedByDivisionView<Storage>& operator=(
+      const GenericPayloadSizedByDivisionView<OtherStorage>&
+          emboss_reserved_local_other) {
+    backing_ = emboss_reserved_local_other.BackingStorage();
+    return *this;
+  }
+
+  bool Ok() const {
+    if (!IsComplete()) return false;
+
+    if (!has_divisor().Known()) return false;
+    if (has_divisor().ValueOrDefault() && !divisor().Ok()) return false;
+
+    if (!has_payload().Known()) return false;
+    if (has_payload().ValueOrDefault() && !payload().Ok()) return false;
+
+    if (!has_IntrinsicSizeInBytes().Known()) return false;
+    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
+        !IntrinsicSizeInBytes().Ok())
+      return false;
+
+    if (!has_MaxSizeInBytes().Known()) return false;
+    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
+      return false;
+
+    if (!has_MinSizeInBytes().Known()) return false;
+    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
+      return false;
+
+    return true;
+  }
+  Storage BackingStorage() const { return backing_; }
+  bool IsComplete() const {
+    return backing_.Ok() && IntrinsicSizeInBytes().Ok() &&
+           backing_.SizeInBytes() >=
+               static_cast</**/ ::std::size_t>(
+                   IntrinsicSizeInBytes().UncheckedRead());
+  }
+  ::std::size_t SizeInBytes() const {
+    return static_cast</**/ ::std::size_t>(IntrinsicSizeInBytes().Read());
+  }
+  bool SizeIsKnown() const { return IntrinsicSizeInBytes().Ok(); }
+
+  template <typename OtherStorage>
+  bool Equals(GenericPayloadSizedByDivisionView<OtherStorage>
+                  emboss_reserved_local_other) const {
+    if (!has_divisor().Known()) return false;
+    if (!emboss_reserved_local_other.has_divisor().Known()) return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        !has_divisor().ValueOrDefault())
+      return false;
+    if (has_divisor().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_divisor().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        has_divisor().ValueOrDefault() &&
+        !divisor().Equals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    if (!has_payload().Known()) return false;
+    if (!emboss_reserved_local_other.has_payload().Known()) return false;
+
+    if (emboss_reserved_local_other.has_payload().ValueOrDefault() &&
+        !has_payload().ValueOrDefault())
+      return false;
+    if (has_payload().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_payload().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_payload().ValueOrDefault() &&
+        has_payload().ValueOrDefault() &&
+        !payload().Equals(emboss_reserved_local_other.payload()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  bool UncheckedEquals(GenericPayloadSizedByDivisionView<OtherStorage>
+                           emboss_reserved_local_other) const {
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        !has_divisor().ValueOr(false))
+      return false;
+    if (has_divisor().ValueOr(false) &&
+        !emboss_reserved_local_other.has_divisor().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        has_divisor().ValueOr(false) &&
+        !divisor().UncheckedEquals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    if (emboss_reserved_local_other.has_payload().ValueOr(false) &&
+        !has_payload().ValueOr(false))
+      return false;
+    if (has_payload().ValueOr(false) &&
+        !emboss_reserved_local_other.has_payload().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_payload().ValueOr(false) &&
+        has_payload().ValueOr(false) &&
+        !payload().UncheckedEquals(emboss_reserved_local_other.payload()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  void UncheckedCopyFrom(GenericPayloadSizedByDivisionView<OtherStorage>
+                             emboss_reserved_local_other) const {
+    backing_.UncheckedCopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().UncheckedRead());
+  }
+
+  template <typename OtherStorage>
+  void CopyFrom(GenericPayloadSizedByDivisionView<OtherStorage>
+                    emboss_reserved_local_other) const {
+    backing_.CopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+  template <typename OtherStorage>
+  bool TryToCopyFrom(GenericPayloadSizedByDivisionView<OtherStorage>
+                         emboss_reserved_local_other) const {
+    return emboss_reserved_local_other.Ok() &&
+           backing_.TryToCopyFrom(
+               emboss_reserved_local_other.BackingStorage(),
+               emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+
+  template <class Stream>
+  bool UpdateFromTextStream(Stream* emboss_reserved_local_stream) const {
+    ::std::string emboss_reserved_local_brace;
+    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                      &emboss_reserved_local_brace))
+      return false;
+    if (emboss_reserved_local_brace != "{") return false;
+    for (;;) {
+      ::std::string emboss_reserved_local_name;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_name))
+        return false;
+      if (emboss_reserved_local_name == ",")
+        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                          &emboss_reserved_local_name))
+          return false;
+      if (emboss_reserved_local_name == "}") return true;
+      ::std::string emboss_reserved_local_colon;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_colon))
+        return false;
+      if (emboss_reserved_local_colon != ":") return false;
+      if (emboss_reserved_local_name == "divisor") {
+        if (!divisor().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (emboss_reserved_local_name == "payload") {
+        if (!payload().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  template <class Stream>
+  void WriteToTextStream(
+      Stream* emboss_reserved_local_stream,
+      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
+    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
+        emboss_reserved_local_options.PlusOneIndent();
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write("{\n");
+    } else {
+      emboss_reserved_local_stream->Write("{");
+    }
+    bool emboss_reserved_local_wrote_field = false;
+    if (has_divisor().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          divisor().IsAggregate() || divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("divisor: ");
+        divisor().WriteToTextStream(emboss_reserved_local_stream,
+                                    emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !divisor().IsAggregate() && !divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# divisor: UNREADABLE\n");
+      }
+    }
+
+    if (has_payload().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          payload().IsAggregate() || payload().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("payload: ");
+        payload().WriteToTextStream(emboss_reserved_local_stream,
+                                    emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !payload().IsAggregate() && !payload().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# payload: UNREADABLE\n");
+      }
+    }
+
+    (void)emboss_reserved_local_wrote_field;
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write(
+          emboss_reserved_local_options.current_indent());
+      emboss_reserved_local_stream->Write("}");
+    } else {
+      emboss_reserved_local_stream->Write(" }");
+    }
+  }
+
+  static constexpr bool IsAggregate() { return true; }
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+  divisor() const;
+  ::emboss::support::Maybe<bool> has_divisor() const;
+
+ public:
+  typename ::emboss::support::GenericArrayView<
+      typename ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType<
+                      /**/ 0, 1>::template OffsetStorageType</**/ 1, 0>>,
+              8>>
+
+      ,
+      typename Storage::template OffsetStorageType</**/ 0, 1>, 1, 8>
+
+  payload() const;
+  ::emboss::support::Maybe<bool> has_payload() const;
+
+ public:
+  class EmbossReservedDollarVirtualIntrinsicSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    explicit EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const GenericPayloadSizedByDivisionView& emboss_reserved_local_view)
+        : view_(emboss_reserved_local_view) {}
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = delete;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = default;
+
+    ::std::int32_t Read() const {
+      EMBOSS_CHECK(view_.has_IntrinsicSizeInBytes().ValueOr(false));
+      auto emboss_reserved_local_value = MaybeRead();
+      EMBOSS_CHECK(emboss_reserved_local_value.Known());
+      EMBOSS_CHECK(ValueIsOk(emboss_reserved_local_value.ValueOrDefault()));
+      return emboss_reserved_local_value.ValueOrDefault();
+    }
+    ::std::int32_t UncheckedRead() const {
+      return MaybeRead().ValueOrDefault();
+    }
+    bool Ok() const {
+      auto emboss_reserved_local_value = MaybeRead();
+      return emboss_reserved_local_value.Known() &&
+             ValueIsOk(emboss_reserved_local_value.ValueOrDefault());
+    }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+
+   private:
+    ::emboss::support::Maybe</**/ ::std::int32_t> MaybeRead() const {
+      const auto emboss_reserved_local_subexpr_1 = view_.divisor();
+      const auto emboss_reserved_local_subexpr_2 =
+          (emboss_reserved_local_subexpr_1.Ok()
+               ? ::emboss::support::Maybe</**/ ::std::int32_t>(
+                     static_cast</**/ ::std::int32_t>(
+                         emboss_reserved_local_subexpr_1.UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::int32_t>());
+      const auto emboss_reserved_local_subexpr_3 =
+          ::emboss::support::FlooringQuotient</**/ ::std::int32_t,
+                                              ::std::int32_t, ::std::int32_t,
+                                              ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(16LL)),
+              emboss_reserved_local_subexpr_2);
+      const auto emboss_reserved_local_subexpr_4 =
+          ::emboss::support::Sum</**/ ::std::int32_t, ::std::int32_t,
+                                 ::std::int32_t, ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(1LL)),
+              emboss_reserved_local_subexpr_3);
+      const auto emboss_reserved_local_subexpr_5 =
+          ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
+                                    ::std::int32_t, ::std::int32_t>(
+              ::emboss::support::Maybe</**/ bool>(true),
+              emboss_reserved_local_subexpr_4,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_6 =
+          ::emboss::support::Maximum</**/ ::std::int32_t, ::std::int32_t,
+                                     ::std::int32_t, ::std::int32_t,
+                                     ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(1LL)),
+              emboss_reserved_local_subexpr_5);
+
+      return emboss_reserved_local_subexpr_6;
+    }
+
+    static constexpr bool ValueIsOk(
+        ::std::int32_t emboss_reserved_local_value) {
+      return (void)emboss_reserved_local_value,  // Silence -Wunused-parameter
+             ::emboss::support::Maybe<bool>(true).ValueOr(false);
+    }
+
+    const GenericPayloadSizedByDivisionView view_;
+  };
+  EmbossReservedDollarVirtualIntrinsicSizeInBytesView IntrinsicSizeInBytes()
+      const;
+  ::emboss::support::Maybe<bool> has_IntrinsicSizeInBytes() const;
+
+ public:
+  class EmbossReservedDollarVirtualMaxSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMaxSizeInBytesView() {}
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMaxSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMaxSizeInBytesView
+  MaxSizeInBytes() {
+    return EmbossReservedDollarVirtualMaxSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MaxSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ public:
+  class EmbossReservedDollarVirtualMinSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMinSizeInBytesView() {}
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMinSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMinSizeInBytesView
+  MinSizeInBytes() {
+    return EmbossReservedDollarVirtualMinSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MinSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ private:
+  Storage backing_;
+
+  template <class OtherStorage>
+  friend class GenericPayloadSizedByDivisionView;
+};
+using PayloadSizedByDivisionView = GenericPayloadSizedByDivisionView<
+    /**/ ::emboss::support::ReadOnlyContiguousBuffer>;
+using PayloadSizedByDivisionWriter = GenericPayloadSizedByDivisionView<
+    /**/ ::emboss::support::ReadWriteContiguousBuffer>;
+
+template <class View>
+struct EmbossReservedInternalIsGenericPayloadSizedByDivisionView {
+  static constexpr const bool value = false;
+};
+
+template <class Storage>
+struct EmbossReservedInternalIsGenericPayloadSizedByDivisionView<
+    GenericPayloadSizedByDivisionView<Storage>> {
+  static constexpr const bool value = true;
+};
+
+template <typename T>
+inline GenericPayloadSizedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<
+        typename ::std::remove_reference<
+            decltype(*::std::declval<T>()->data())>::type,
+        1, 0>>
+MakePayloadSizedByDivisionView(T&& emboss_reserved_local_arg) {
+  return GenericPayloadSizedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<
+          typename ::std::remove_reference<
+              decltype(*::std::declval<T>()->data())>::type,
+          1, 0>>(::std::forward<T>(emboss_reserved_local_arg));
+}
+
+template <typename T>
+inline GenericPayloadSizedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>
+MakePayloadSizedByDivisionView(T* emboss_reserved_local_data,
+                               ::std::size_t emboss_reserved_local_size) {
+  return GenericPayloadSizedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+template <typename T, ::std::size_t kAlignment>
+inline GenericPayloadSizedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>
+MakeAlignedPayloadSizedByDivisionView(
+    T* emboss_reserved_local_data, ::std::size_t emboss_reserved_local_size) {
+  return GenericPayloadSizedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+namespace FieldGatedByDivision {}  // namespace FieldGatedByDivision
+
+template <class View>
+struct EmbossReservedInternalIsGenericFieldGatedByDivisionView;
+
+template <class Storage>
+class GenericFieldGatedByDivisionView final {
+ public:
+  GenericFieldGatedByDivisionView() : backing_() {}
+  explicit GenericFieldGatedByDivisionView(Storage emboss_reserved_local_bytes)
+      : backing_(emboss_reserved_local_bytes) {}
+
+  template <typename OtherStorage>
+  GenericFieldGatedByDivisionView(
+      const GenericFieldGatedByDivisionView<OtherStorage>&
+          emboss_reserved_local_other)
+      : backing_{emboss_reserved_local_other.BackingStorage()} {}
+
+  template <typename Arg,
+            typename = typename ::std::enable_if<
+                !EmbossReservedInternalIsGenericFieldGatedByDivisionView<
+                    typename ::std::remove_cv<typename ::std::remove_reference<
+                        Arg>::type>::type>::value>::type>
+  explicit GenericFieldGatedByDivisionView(Arg&& emboss_reserved_local_arg)
+      : backing_(::std::forward<Arg>(emboss_reserved_local_arg)) {}
+  template <typename Arg0, typename Arg1, typename... Args>
+  explicit GenericFieldGatedByDivisionView(Arg0&& emboss_reserved_local_arg0,
+                                           Arg1&& emboss_reserved_local_arg1,
+                                           Args&&... emboss_reserved_local_args)
+      : backing_(::std::forward<Arg0>(emboss_reserved_local_arg0),
+                 ::std::forward<Arg1>(emboss_reserved_local_arg1),
+                 ::std::forward<Args>(emboss_reserved_local_args)...) {}
+
+  template <typename OtherStorage>
+  GenericFieldGatedByDivisionView<Storage>& operator=(
+      const GenericFieldGatedByDivisionView<OtherStorage>&
+          emboss_reserved_local_other) {
+    backing_ = emboss_reserved_local_other.BackingStorage();
+    return *this;
+  }
+
+  bool Ok() const {
+    if (!IsComplete()) return false;
+
+    if (!has_divisor().Known()) return false;
+    if (has_divisor().ValueOrDefault() && !divisor().Ok()) return false;
+
+    if (!has_IntrinsicSizeInBytes().Known()) return false;
+    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
+        !IntrinsicSizeInBytes().Ok())
+      return false;
+
+    if (!has_MaxSizeInBytes().Known()) return false;
+    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
+      return false;
+
+    if (!has_MinSizeInBytes().Known()) return false;
+    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
+      return false;
+
+    if (!has_gated().Known()) return false;
+    if (has_gated().ValueOrDefault() && !gated().Ok()) return false;
+
+    return true;
+  }
+  Storage BackingStorage() const { return backing_; }
+  bool IsComplete() const {
+    return backing_.Ok() && IntrinsicSizeInBytes().Ok() &&
+           backing_.SizeInBytes() >=
+               static_cast</**/ ::std::size_t>(
+                   IntrinsicSizeInBytes().UncheckedRead());
+  }
+  ::std::size_t SizeInBytes() const {
+    return static_cast</**/ ::std::size_t>(IntrinsicSizeInBytes().Read());
+  }
+  bool SizeIsKnown() const { return IntrinsicSizeInBytes().Ok(); }
+
+  template <typename OtherStorage>
+  bool Equals(GenericFieldGatedByDivisionView<OtherStorage>
+                  emboss_reserved_local_other) const {
+    if (!has_divisor().Known()) return false;
+    if (!emboss_reserved_local_other.has_divisor().Known()) return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        !has_divisor().ValueOrDefault())
+      return false;
+    if (has_divisor().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_divisor().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        has_divisor().ValueOrDefault() &&
+        !divisor().Equals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    if (!has_gated().Known()) return false;
+    if (!emboss_reserved_local_other.has_gated().Known()) return false;
+
+    if (emboss_reserved_local_other.has_gated().ValueOrDefault() &&
+        !has_gated().ValueOrDefault())
+      return false;
+    if (has_gated().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_gated().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_gated().ValueOrDefault() &&
+        has_gated().ValueOrDefault() &&
+        !gated().Equals(emboss_reserved_local_other.gated()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  bool UncheckedEquals(GenericFieldGatedByDivisionView<OtherStorage>
+                           emboss_reserved_local_other) const {
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        !has_divisor().ValueOr(false))
+      return false;
+    if (has_divisor().ValueOr(false) &&
+        !emboss_reserved_local_other.has_divisor().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        has_divisor().ValueOr(false) &&
+        !divisor().UncheckedEquals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    if (emboss_reserved_local_other.has_gated().ValueOr(false) &&
+        !has_gated().ValueOr(false))
+      return false;
+    if (has_gated().ValueOr(false) &&
+        !emboss_reserved_local_other.has_gated().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_gated().ValueOr(false) &&
+        has_gated().ValueOr(false) &&
+        !gated().UncheckedEquals(emboss_reserved_local_other.gated()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  void UncheckedCopyFrom(GenericFieldGatedByDivisionView<OtherStorage>
+                             emboss_reserved_local_other) const {
+    backing_.UncheckedCopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().UncheckedRead());
+  }
+
+  template <typename OtherStorage>
+  void CopyFrom(GenericFieldGatedByDivisionView<OtherStorage>
+                    emboss_reserved_local_other) const {
+    backing_.CopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+  template <typename OtherStorage>
+  bool TryToCopyFrom(GenericFieldGatedByDivisionView<OtherStorage>
+                         emboss_reserved_local_other) const {
+    return emboss_reserved_local_other.Ok() &&
+           backing_.TryToCopyFrom(
+               emboss_reserved_local_other.BackingStorage(),
+               emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+
+  template <class Stream>
+  bool UpdateFromTextStream(Stream* emboss_reserved_local_stream) const {
+    ::std::string emboss_reserved_local_brace;
+    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                      &emboss_reserved_local_brace))
+      return false;
+    if (emboss_reserved_local_brace != "{") return false;
+    for (;;) {
+      ::std::string emboss_reserved_local_name;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_name))
+        return false;
+      if (emboss_reserved_local_name == ",")
+        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                          &emboss_reserved_local_name))
+          return false;
+      if (emboss_reserved_local_name == "}") return true;
+      ::std::string emboss_reserved_local_colon;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_colon))
+        return false;
+      if (emboss_reserved_local_colon != ":") return false;
+      if (emboss_reserved_local_name == "divisor") {
+        if (!divisor().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      if (emboss_reserved_local_name == "gated") {
+        if (!gated().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  template <class Stream>
+  void WriteToTextStream(
+      Stream* emboss_reserved_local_stream,
+      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
+    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
+        emboss_reserved_local_options.PlusOneIndent();
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write("{\n");
+    } else {
+      emboss_reserved_local_stream->Write("{");
+    }
+    bool emboss_reserved_local_wrote_field = false;
+    if (has_divisor().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          divisor().IsAggregate() || divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("divisor: ");
+        divisor().WriteToTextStream(emboss_reserved_local_stream,
+                                    emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !divisor().IsAggregate() && !divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# divisor: UNREADABLE\n");
+      }
+    }
+
+    if (has_gated().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          gated().IsAggregate() || gated().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("gated: ");
+        gated().WriteToTextStream(emboss_reserved_local_stream,
+                                  emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !gated().IsAggregate() && !gated().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# gated: UNREADABLE\n");
+      }
+    }
+
+    (void)emboss_reserved_local_wrote_field;
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write(
+          emboss_reserved_local_options.current_indent());
+      emboss_reserved_local_stream->Write("}");
+    } else {
+      emboss_reserved_local_stream->Write(" }");
+    }
+  }
+
+  static constexpr bool IsAggregate() { return true; }
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+  divisor() const;
+  ::emboss::support::Maybe<bool> has_divisor() const;
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 1>>,
+          8>>
+
+  gated() const;
+  ::emboss::support::Maybe<bool> has_gated() const;
+
+ public:
+  class EmbossReservedDollarVirtualIntrinsicSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    explicit EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const GenericFieldGatedByDivisionView& emboss_reserved_local_view)
+        : view_(emboss_reserved_local_view) {}
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = delete;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = default;
+
+    ::std::int32_t Read() const {
+      EMBOSS_CHECK(view_.has_IntrinsicSizeInBytes().ValueOr(false));
+      auto emboss_reserved_local_value = MaybeRead();
+      EMBOSS_CHECK(emboss_reserved_local_value.Known());
+      EMBOSS_CHECK(ValueIsOk(emboss_reserved_local_value.ValueOrDefault()));
+      return emboss_reserved_local_value.ValueOrDefault();
+    }
+    ::std::int32_t UncheckedRead() const {
+      return MaybeRead().ValueOrDefault();
+    }
+    bool Ok() const {
+      auto emboss_reserved_local_value = MaybeRead();
+      return emboss_reserved_local_value.Known() &&
+             ValueIsOk(emboss_reserved_local_value.ValueOrDefault());
+    }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+
+   private:
+    ::emboss::support::Maybe</**/ ::std::int32_t> MaybeRead() const {
+      const auto emboss_reserved_local_subexpr_1 = view_.divisor();
+      const auto emboss_reserved_local_subexpr_2 =
+          (emboss_reserved_local_subexpr_1.Ok()
+               ? ::emboss::support::Maybe</**/ ::std::int32_t>(
+                     static_cast</**/ ::std::int32_t>(
+                         emboss_reserved_local_subexpr_1.UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::int32_t>());
+      const auto emboss_reserved_local_subexpr_3 =
+          ::emboss::support::FlooringQuotient</**/ ::std::int32_t,
+                                              ::std::int32_t, ::std::int32_t,
+                                              ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(12LL)),
+              emboss_reserved_local_subexpr_2);
+      const auto emboss_reserved_local_subexpr_4 =
+          ::emboss::support::Equal</**/ ::std::int32_t, bool, ::std::int32_t,
+                                   ::std::int32_t>(
+              emboss_reserved_local_subexpr_3,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(3LL)));
+      const auto emboss_reserved_local_subexpr_5 =
+          ::emboss::support::Choice</**/ ::std::int32_t, ::std::int32_t, bool,
+                                    ::std::int32_t, ::std::int32_t>(
+              emboss_reserved_local_subexpr_4,
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(2LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)));
+      const auto emboss_reserved_local_subexpr_6 =
+          ::emboss::support::Maximum</**/ ::std::int32_t, ::std::int32_t,
+                                     ::std::int32_t, ::std::int32_t,
+                                     ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)),
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(1LL)),
+              emboss_reserved_local_subexpr_5);
+
+      return emboss_reserved_local_subexpr_6;
+    }
+
+    static constexpr bool ValueIsOk(
+        ::std::int32_t emboss_reserved_local_value) {
+      return (void)emboss_reserved_local_value,  // Silence -Wunused-parameter
+             ::emboss::support::Maybe<bool>(true).ValueOr(false);
+    }
+
+    const GenericFieldGatedByDivisionView view_;
+  };
+  EmbossReservedDollarVirtualIntrinsicSizeInBytesView IntrinsicSizeInBytes()
+      const;
+  ::emboss::support::Maybe<bool> has_IntrinsicSizeInBytes() const;
+
+ public:
+  class EmbossReservedDollarVirtualMaxSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMaxSizeInBytesView() {}
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMaxSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMaxSizeInBytesView
+  MaxSizeInBytes() {
+    return EmbossReservedDollarVirtualMaxSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MaxSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ public:
+  class EmbossReservedDollarVirtualMinSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMinSizeInBytesView() {}
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMinSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMinSizeInBytesView
+  MinSizeInBytes() {
+    return EmbossReservedDollarVirtualMinSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MinSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ private:
+  Storage backing_;
+
+  template <class OtherStorage>
+  friend class GenericFieldGatedByDivisionView;
+};
+using FieldGatedByDivisionView = GenericFieldGatedByDivisionView<
+    /**/ ::emboss::support::ReadOnlyContiguousBuffer>;
+using FieldGatedByDivisionWriter = GenericFieldGatedByDivisionView<
+    /**/ ::emboss::support::ReadWriteContiguousBuffer>;
+
+template <class View>
+struct EmbossReservedInternalIsGenericFieldGatedByDivisionView {
+  static constexpr const bool value = false;
+};
+
+template <class Storage>
+struct EmbossReservedInternalIsGenericFieldGatedByDivisionView<
+    GenericFieldGatedByDivisionView<Storage>> {
+  static constexpr const bool value = true;
+};
+
+template <typename T>
+inline GenericFieldGatedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<
+        typename ::std::remove_reference<
+            decltype(*::std::declval<T>()->data())>::type,
+        1, 0>>
+MakeFieldGatedByDivisionView(T&& emboss_reserved_local_arg) {
+  return GenericFieldGatedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<
+          typename ::std::remove_reference<
+              decltype(*::std::declval<T>()->data())>::type,
+          1, 0>>(::std::forward<T>(emboss_reserved_local_arg));
+}
+
+template <typename T>
+inline GenericFieldGatedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>
+MakeFieldGatedByDivisionView(T* emboss_reserved_local_data,
+                             ::std::size_t emboss_reserved_local_size) {
+  return GenericFieldGatedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+template <typename T, ::std::size_t kAlignment>
+inline GenericFieldGatedByDivisionView<
+    /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>
+MakeAlignedFieldGatedByDivisionView(T* emboss_reserved_local_data,
+                                    ::std::size_t emboss_reserved_local_size) {
+  return GenericFieldGatedByDivisionView<
+      /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+namespace CollapsingQuotient {}  // namespace CollapsingQuotient
+
+template <class View>
+struct EmbossReservedInternalIsGenericCollapsingQuotientView;
+
+template <class Storage>
+class GenericCollapsingQuotientView final {
+ public:
+  GenericCollapsingQuotientView() : backing_() {}
+  explicit GenericCollapsingQuotientView(Storage emboss_reserved_local_bytes)
+      : backing_(emboss_reserved_local_bytes) {}
+
+  template <typename OtherStorage>
+  GenericCollapsingQuotientView(
+      const GenericCollapsingQuotientView<OtherStorage>&
+          emboss_reserved_local_other)
+      : backing_{emboss_reserved_local_other.BackingStorage()} {}
+
+  template <typename Arg,
+            typename = typename ::std::enable_if<
+                !EmbossReservedInternalIsGenericCollapsingQuotientView<
+                    typename ::std::remove_cv<typename ::std::remove_reference<
+                        Arg>::type>::type>::value>::type>
+  explicit GenericCollapsingQuotientView(Arg&& emboss_reserved_local_arg)
+      : backing_(::std::forward<Arg>(emboss_reserved_local_arg)) {}
+  template <typename Arg0, typename Arg1, typename... Args>
+  explicit GenericCollapsingQuotientView(Arg0&& emboss_reserved_local_arg0,
+                                         Arg1&& emboss_reserved_local_arg1,
+                                         Args&&... emboss_reserved_local_args)
+      : backing_(::std::forward<Arg0>(emboss_reserved_local_arg0),
+                 ::std::forward<Arg1>(emboss_reserved_local_arg1),
+                 ::std::forward<Args>(emboss_reserved_local_args)...) {}
+
+  template <typename OtherStorage>
+  GenericCollapsingQuotientView<Storage>& operator=(
+      const GenericCollapsingQuotientView<OtherStorage>&
+          emboss_reserved_local_other) {
+    backing_ = emboss_reserved_local_other.BackingStorage();
+    return *this;
+  }
+
+  bool Ok() const {
+    if (!IsComplete()) return false;
+
+    if (!has_divisor().Known()) return false;
+    if (has_divisor().ValueOrDefault() && !divisor().Ok()) return false;
+
+    if (!has_zero_or_undefined().Known()) return false;
+    if (has_zero_or_undefined().ValueOrDefault() && !zero_or_undefined().Ok())
+      return false;
+
+    if (!has_IntrinsicSizeInBytes().Known()) return false;
+    if (has_IntrinsicSizeInBytes().ValueOrDefault() &&
+        !IntrinsicSizeInBytes().Ok())
+      return false;
+
+    if (!has_MaxSizeInBytes().Known()) return false;
+    if (has_MaxSizeInBytes().ValueOrDefault() && !MaxSizeInBytes().Ok())
+      return false;
+
+    if (!has_MinSizeInBytes().Known()) return false;
+    if (has_MinSizeInBytes().ValueOrDefault() && !MinSizeInBytes().Ok())
+      return false;
+
+    return true;
+  }
+  Storage BackingStorage() const { return backing_; }
+  bool IsComplete() const {
+    return backing_.Ok() && IntrinsicSizeInBytes().Ok() &&
+           backing_.SizeInBytes() >=
+               static_cast</**/ ::std::size_t>(
+                   IntrinsicSizeInBytes().UncheckedRead());
+  }
+  static constexpr ::std::size_t SizeInBytes() {
+    return static_cast</**/ ::std::size_t>(IntrinsicSizeInBytes().Read());
+  }
+  static constexpr bool SizeIsKnown() { return IntrinsicSizeInBytes().Ok(); }
+
+  template <typename OtherStorage>
+  bool Equals(GenericCollapsingQuotientView<OtherStorage>
+                  emboss_reserved_local_other) const {
+    if (!has_divisor().Known()) return false;
+    if (!emboss_reserved_local_other.has_divisor().Known()) return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        !has_divisor().ValueOrDefault())
+      return false;
+    if (has_divisor().ValueOrDefault() &&
+        !emboss_reserved_local_other.has_divisor().ValueOrDefault())
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOrDefault() &&
+        has_divisor().ValueOrDefault() &&
+        !divisor().Equals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  bool UncheckedEquals(GenericCollapsingQuotientView<OtherStorage>
+                           emboss_reserved_local_other) const {
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        !has_divisor().ValueOr(false))
+      return false;
+    if (has_divisor().ValueOr(false) &&
+        !emboss_reserved_local_other.has_divisor().ValueOr(false))
+      return false;
+
+    if (emboss_reserved_local_other.has_divisor().ValueOr(false) &&
+        has_divisor().ValueOr(false) &&
+        !divisor().UncheckedEquals(emboss_reserved_local_other.divisor()))
+      return false;
+
+    return true;
+  }
+  template <typename OtherStorage>
+  void UncheckedCopyFrom(GenericCollapsingQuotientView<OtherStorage>
+                             emboss_reserved_local_other) const {
+    backing_.UncheckedCopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().UncheckedRead());
+  }
+
+  template <typename OtherStorage>
+  void CopyFrom(GenericCollapsingQuotientView<OtherStorage>
+                    emboss_reserved_local_other) const {
+    backing_.CopyFrom(
+        emboss_reserved_local_other.BackingStorage(),
+        emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+  template <typename OtherStorage>
+  bool TryToCopyFrom(GenericCollapsingQuotientView<OtherStorage>
+                         emboss_reserved_local_other) const {
+    return emboss_reserved_local_other.Ok() &&
+           backing_.TryToCopyFrom(
+               emboss_reserved_local_other.BackingStorage(),
+               emboss_reserved_local_other.IntrinsicSizeInBytes().Read());
+  }
+
+  template <class Stream>
+  bool UpdateFromTextStream(Stream* emboss_reserved_local_stream) const {
+    ::std::string emboss_reserved_local_brace;
+    if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                      &emboss_reserved_local_brace))
+      return false;
+    if (emboss_reserved_local_brace != "{") return false;
+    for (;;) {
+      ::std::string emboss_reserved_local_name;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_name))
+        return false;
+      if (emboss_reserved_local_name == ",")
+        if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                          &emboss_reserved_local_name))
+          return false;
+      if (emboss_reserved_local_name == "}") return true;
+      ::std::string emboss_reserved_local_colon;
+      if (!::emboss::support::ReadToken(emboss_reserved_local_stream,
+                                        &emboss_reserved_local_colon))
+        return false;
+      if (emboss_reserved_local_colon != ":") return false;
+      if (emboss_reserved_local_name == "divisor") {
+        if (!divisor().UpdateFromTextStream(emboss_reserved_local_stream)) {
+          return false;
+        }
+        continue;
+      }
+
+      return false;
+    }
+  }
+
+  template <class Stream>
+  void WriteToTextStream(
+      Stream* emboss_reserved_local_stream,
+      ::emboss::TextOutputOptions emboss_reserved_local_options) const {
+    ::emboss::TextOutputOptions emboss_reserved_local_field_options =
+        emboss_reserved_local_options.PlusOneIndent();
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write("{\n");
+    } else {
+      emboss_reserved_local_stream->Write("{");
+    }
+    bool emboss_reserved_local_wrote_field = false;
+    if (has_divisor().ValueOr(false)) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          divisor().IsAggregate() || divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        } else {
+          if (emboss_reserved_local_wrote_field) {
+            emboss_reserved_local_stream->Write(",");
+          }
+          emboss_reserved_local_stream->Write(" ");
+        }
+        emboss_reserved_local_stream->Write("divisor: ");
+        divisor().WriteToTextStream(emboss_reserved_local_stream,
+                                    emboss_reserved_local_field_options);
+        emboss_reserved_local_wrote_field = true;
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write("\n");
+        }
+      } else if (emboss_reserved_local_field_options.allow_partial_output() &&
+                 emboss_reserved_local_field_options.comments() &&
+                 !divisor().IsAggregate() && !divisor().Ok()) {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write("# divisor: UNREADABLE\n");
+      }
+    }
+
+    if (has_zero_or_undefined().ValueOr(false) &&
+        emboss_reserved_local_field_options.comments()) {
+      if (!emboss_reserved_local_field_options.allow_partial_output() ||
+          zero_or_undefined().IsAggregate() || zero_or_undefined().Ok()) {
+        emboss_reserved_local_stream->Write(
+            emboss_reserved_local_field_options.current_indent());
+        emboss_reserved_local_stream->Write("# zero_or_undefined: ");
+        zero_or_undefined().WriteToTextStream(
+            emboss_reserved_local_stream, emboss_reserved_local_field_options);
+        emboss_reserved_local_stream->Write("\n");
+      } else {
+        if (emboss_reserved_local_field_options.multiline()) {
+          emboss_reserved_local_stream->Write(
+              emboss_reserved_local_field_options.current_indent());
+        }
+        emboss_reserved_local_stream->Write(
+            "# zero_or_undefined: UNREADABLE\n");
+      }
+    }
+
+    (void)emboss_reserved_local_wrote_field;
+    if (emboss_reserved_local_options.multiline()) {
+      emboss_reserved_local_stream->Write(
+          emboss_reserved_local_options.current_indent());
+      emboss_reserved_local_stream->Write("}");
+    } else {
+      emboss_reserved_local_stream->Write(" }");
+    }
+  }
+
+  static constexpr bool IsAggregate() { return true; }
+
+ public:
+  typename ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+  divisor() const;
+  ::emboss::support::Maybe<bool> has_divisor() const;
+
+ public:
+  class EmbossReservedVirtualZeroOrUndefinedView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    explicit EmbossReservedVirtualZeroOrUndefinedView(
+        const GenericCollapsingQuotientView& emboss_reserved_local_view)
+        : view_(emboss_reserved_local_view) {}
+    EmbossReservedVirtualZeroOrUndefinedView() = delete;
+    EmbossReservedVirtualZeroOrUndefinedView(
+        const EmbossReservedVirtualZeroOrUndefinedView&) = default;
+    EmbossReservedVirtualZeroOrUndefinedView(
+        EmbossReservedVirtualZeroOrUndefinedView&&) = default;
+    EmbossReservedVirtualZeroOrUndefinedView& operator=(
+        const EmbossReservedVirtualZeroOrUndefinedView&) = default;
+    EmbossReservedVirtualZeroOrUndefinedView& operator=(
+        EmbossReservedVirtualZeroOrUndefinedView&&) = default;
+    ~EmbossReservedVirtualZeroOrUndefinedView() = default;
+
+    ::std::int32_t Read() const {
+      EMBOSS_CHECK(view_.has_zero_or_undefined().ValueOr(false));
+      auto emboss_reserved_local_value = MaybeRead();
+      EMBOSS_CHECK(emboss_reserved_local_value.Known());
+      EMBOSS_CHECK(ValueIsOk(emboss_reserved_local_value.ValueOrDefault()));
+      return emboss_reserved_local_value.ValueOrDefault();
+    }
+    ::std::int32_t UncheckedRead() const {
+      return MaybeRead().ValueOrDefault();
+    }
+    bool Ok() const {
+      auto emboss_reserved_local_value = MaybeRead();
+      return emboss_reserved_local_value.Known() &&
+             ValueIsOk(emboss_reserved_local_value.ValueOrDefault());
+    }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+
+   private:
+    ::emboss::support::Maybe</**/ ::std::int32_t> MaybeRead() const {
+      const auto emboss_reserved_local_subexpr_1 = view_.divisor();
+      const auto emboss_reserved_local_subexpr_2 =
+          (emboss_reserved_local_subexpr_1.Ok()
+               ? ::emboss::support::Maybe</**/ ::std::int32_t>(
+                     static_cast</**/ ::std::int32_t>(
+                         emboss_reserved_local_subexpr_1.UncheckedRead()))
+               : ::emboss::support::Maybe</**/ ::std::int32_t>());
+      const auto emboss_reserved_local_subexpr_3 =
+          ::emboss::support::FlooringQuotient</**/ ::std::int32_t,
+                                              ::std::int32_t, ::std::int32_t,
+                                              ::std::int32_t>(
+              ::emboss::support::Maybe</**/ ::std::int32_t>(
+                  static_cast</**/ ::std::int32_t>(0LL)),
+              emboss_reserved_local_subexpr_2);
+
+      return emboss_reserved_local_subexpr_3;
+    }
+
+    static constexpr bool ValueIsOk(
+        ::std::int32_t emboss_reserved_local_value) {
+      return (void)emboss_reserved_local_value,  // Silence -Wunused-parameter
+             ::emboss::support::Maybe<bool>(true).ValueOr(false);
+    }
+
+    const GenericCollapsingQuotientView view_;
+  };
+  EmbossReservedVirtualZeroOrUndefinedView zero_or_undefined() const;
+  ::emboss::support::Maybe<bool> has_zero_or_undefined() const;
+
+ public:
+  class EmbossReservedDollarVirtualIntrinsicSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualIntrinsicSizeInBytesView() {}
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualIntrinsicSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualIntrinsicSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualIntrinsicSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualIntrinsicSizeInBytesView
+  IntrinsicSizeInBytes() {
+    return EmbossReservedDollarVirtualIntrinsicSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_IntrinsicSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ public:
+  class EmbossReservedDollarVirtualMaxSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMaxSizeInBytesView() {}
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMaxSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMaxSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMaxSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMaxSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMaxSizeInBytesView
+  MaxSizeInBytes() {
+    return EmbossReservedDollarVirtualMaxSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MaxSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ public:
+  class EmbossReservedDollarVirtualMinSizeInBytesView final {
+   public:
+    using ValueType = ::std::int32_t;
+
+    constexpr EmbossReservedDollarVirtualMinSizeInBytesView() {}
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        const EmbossReservedDollarVirtualMinSizeInBytesView&) = default;
+    EmbossReservedDollarVirtualMinSizeInBytesView& operator=(
+        EmbossReservedDollarVirtualMinSizeInBytesView&&) = default;
+    ~EmbossReservedDollarVirtualMinSizeInBytesView() = default;
+
+    static constexpr ::std::int32_t Read();
+    static constexpr ::std::int32_t UncheckedRead();
+    static constexpr bool Ok() { return true; }
+    template <class Stream>
+    void WriteToTextStream(Stream* emboss_reserved_local_stream,
+                           const ::emboss::TextOutputOptions&
+                               emboss_reserved_local_options) const {
+      ::emboss::support::WriteIntegerViewToTextStream(
+          this, emboss_reserved_local_stream, emboss_reserved_local_options);
+    }
+
+    static constexpr bool IsAggregate() { return false; }
+  };
+
+  static constexpr EmbossReservedDollarVirtualMinSizeInBytesView
+  MinSizeInBytes() {
+    return EmbossReservedDollarVirtualMinSizeInBytesView();
+  }
+  static constexpr ::emboss::support::Maybe<bool> has_MinSizeInBytes() {
+    return ::emboss::support::Maybe<bool>(true);
+  }
+
+ private:
+  Storage backing_;
+
+  template <class OtherStorage>
+  friend class GenericCollapsingQuotientView;
+};
+using CollapsingQuotientView = GenericCollapsingQuotientView<
+    /**/ ::emboss::support::ReadOnlyContiguousBuffer>;
+using CollapsingQuotientWriter = GenericCollapsingQuotientView<
+    /**/ ::emboss::support::ReadWriteContiguousBuffer>;
+
+template <class View>
+struct EmbossReservedInternalIsGenericCollapsingQuotientView {
+  static constexpr const bool value = false;
+};
+
+template <class Storage>
+struct EmbossReservedInternalIsGenericCollapsingQuotientView<
+    GenericCollapsingQuotientView<Storage>> {
+  static constexpr const bool value = true;
+};
+
+template <typename T>
+inline GenericCollapsingQuotientView<
+    /**/ ::emboss::support::ContiguousBuffer<
+        typename ::std::remove_reference<
+            decltype(*::std::declval<T>()->data())>::type,
+        1, 0>>
+MakeCollapsingQuotientView(T&& emboss_reserved_local_arg) {
+  return GenericCollapsingQuotientView<
+      /**/ ::emboss::support::ContiguousBuffer<
+          typename ::std::remove_reference<
+              decltype(*::std::declval<T>()->data())>::type,
+          1, 0>>(::std::forward<T>(emboss_reserved_local_arg));
+}
+
+template <typename T>
+inline GenericCollapsingQuotientView<
+    /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>
+MakeCollapsingQuotientView(T* emboss_reserved_local_data,
+                           ::std::size_t emboss_reserved_local_size) {
+  return GenericCollapsingQuotientView<
+      /**/ ::emboss::support::ContiguousBuffer<T, 1, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
+template <typename T, ::std::size_t kAlignment>
+inline GenericCollapsingQuotientView<
+    /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>
+MakeAlignedCollapsingQuotientView(T* emboss_reserved_local_data,
+                                  ::std::size_t emboss_reserved_local_size) {
+  return GenericCollapsingQuotientView<
+      /**/ ::emboss::support::ContiguousBuffer<T, kAlignment, 0>>(
+      emboss_reserved_local_data, emboss_reserved_local_size);
+}
+
 namespace ArrayOfUint16BySizeInBytes {}  // namespace ArrayOfUint16BySizeInBytes
 
 template <class Storage>
@@ -2646,6 +4257,484 @@ template <class Storage>
 inline constexpr ::std::int32_t GenericConstantsView<
     Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
   return Constants::MinSizeInBytes();
+}
+namespace PayloadSizedByDivision {}  // namespace PayloadSizedByDivision
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        8, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 0>>,
+        8>>
+
+GenericPayloadSizedByDivisionView<Storage>::divisor() const {
+  if (has_divisor().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(0LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 0>>,
+              8>>
+
+          (backing_.template GetOffsetStorage<0, 0>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericPayloadSizedByDivisionView<Storage>::has_divisor() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+template <class Storage>
+inline typename ::emboss::support::GenericArrayView<
+    typename ::emboss::prelude::UIntView<
+        /**/ ::emboss::support::FixedSizeViewParameters<
+            8, ::emboss::support::AllValuesAreOk>,
+        typename ::emboss::support::BitBlock<
+            /**/ ::emboss::support::LittleEndianByteOrderer<
+                typename Storage::template OffsetStorageType<
+                    /**/ 0, 1>::template OffsetStorageType</**/ 1, 0>>,
+            8>>
+
+    ,
+    typename Storage::template OffsetStorageType</**/ 0, 1>, 1, 8>
+
+GenericPayloadSizedByDivisionView<Storage>::payload() const {
+  if (has_payload().ValueOr(false)) {
+    const auto emboss_reserved_local_subexpr_1 = divisor();
+    const auto emboss_reserved_local_subexpr_2 =
+        (emboss_reserved_local_subexpr_1.Ok()
+             ? ::emboss::support::Maybe</**/ ::std::int32_t>(
+                   static_cast</**/ ::std::int32_t>(
+                       emboss_reserved_local_subexpr_1.UncheckedRead()))
+             : ::emboss::support::Maybe</**/ ::std::int32_t>());
+    const auto emboss_reserved_local_subexpr_3 =
+        ::emboss::support::FlooringQuotient</**/ ::std::int32_t, ::std::int32_t,
+                                            ::std::int32_t, ::std::int32_t>(
+            ::emboss::support::Maybe</**/ ::std::int32_t>(
+                static_cast</**/ ::std::int32_t>(16LL)),
+            emboss_reserved_local_subexpr_2);
+
+    auto emboss_reserved_local_size = emboss_reserved_local_subexpr_3;
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::support::GenericArrayView<
+          typename ::emboss::prelude::UIntView<
+              /**/ ::emboss::support::FixedSizeViewParameters<
+                  8, ::emboss::support::AllValuesAreOk>,
+              typename ::emboss::support::BitBlock<
+                  /**/ ::emboss::support::LittleEndianByteOrderer<
+                      typename Storage::template OffsetStorageType<
+                          /**/ 0, 1>::template OffsetStorageType</**/ 1, 0>>,
+                  8>>
+
+          ,
+          typename Storage::template OffsetStorageType</**/ 0, 1>, 1, 8>
+
+          (backing_.template GetOffsetStorage<0, 1>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::support::GenericArrayView<
+      typename ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType<
+                      /**/ 0, 1>::template OffsetStorageType</**/ 1, 0>>,
+              8>>
+
+      ,
+      typename Storage::template OffsetStorageType</**/ 0, 1>, 1, 8>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericPayloadSizedByDivisionView<Storage>::has_payload() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+template <class Storage>
+inline typename GenericPayloadSizedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView
+GenericPayloadSizedByDivisionView<Storage>::IntrinsicSizeInBytes() const {
+  return typename GenericPayloadSizedByDivisionView<
+      Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView(*this);
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericPayloadSizedByDivisionView<Storage>::has_IntrinsicSizeInBytes() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+namespace PayloadSizedByDivision {
+inline constexpr ::std::int32_t MaxSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(17LL))
+      .ValueOrDefault();
+}
+}  // namespace PayloadSizedByDivision
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericPayloadSizedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::Read() {
+  return PayloadSizedByDivision::MaxSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericPayloadSizedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::UncheckedRead() {
+  return PayloadSizedByDivision::MaxSizeInBytes();
+}
+
+namespace PayloadSizedByDivision {
+inline constexpr ::std::int32_t MinSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(1LL))
+      .ValueOrDefault();
+}
+}  // namespace PayloadSizedByDivision
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericPayloadSizedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::Read() {
+  return PayloadSizedByDivision::MinSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericPayloadSizedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
+  return PayloadSizedByDivision::MinSizeInBytes();
+}
+namespace FieldGatedByDivision {}  // namespace FieldGatedByDivision
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        8, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 0>>,
+        8>>
+
+GenericFieldGatedByDivisionView<Storage>::divisor() const {
+  if (has_divisor().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(0LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 0>>,
+              8>>
+
+          (backing_.template GetOffsetStorage<0, 0>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericFieldGatedByDivisionView<Storage>::has_divisor() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        8, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 1>>,
+        8>>
+
+GenericFieldGatedByDivisionView<Storage>::gated() const {
+  if (has_gated().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 1>>,
+              8>>
+
+          (backing_.template GetOffsetStorage<0, 1>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 1>>,
+          8>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericFieldGatedByDivisionView<Storage>::has_gated() const {
+  return ::emboss::support::Equal</**/ ::std::int32_t, bool, ::std::int32_t,
+                                  ::std::int32_t>(
+      ::emboss::support::FlooringQuotient</**/ ::std::int32_t, ::std::int32_t,
+                                          ::std::int32_t, ::std::int32_t>(
+          ::emboss::support::Maybe</**/ ::std::int32_t>(
+              static_cast</**/ ::std::int32_t>(12LL)),
+          (divisor().Ok() ? ::emboss::support::Maybe</**/ ::std::int32_t>(
+                                static_cast</**/ ::std::int32_t>(
+                                    divisor().UncheckedRead()))
+                          : ::emboss::support::Maybe</**/ ::std::int32_t>())),
+      ::emboss::support::Maybe</**/ ::std::int32_t>(
+          static_cast</**/ ::std::int32_t>(3LL)));
+}
+
+template <class Storage>
+inline typename GenericFieldGatedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView
+GenericFieldGatedByDivisionView<Storage>::IntrinsicSizeInBytes() const {
+  return typename GenericFieldGatedByDivisionView<
+      Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView(*this);
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericFieldGatedByDivisionView<Storage>::has_IntrinsicSizeInBytes() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+namespace FieldGatedByDivision {
+inline constexpr ::std::int32_t MaxSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(2LL))
+      .ValueOrDefault();
+}
+}  // namespace FieldGatedByDivision
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericFieldGatedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::Read() {
+  return FieldGatedByDivision::MaxSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericFieldGatedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::UncheckedRead() {
+  return FieldGatedByDivision::MaxSizeInBytes();
+}
+
+namespace FieldGatedByDivision {
+inline constexpr ::std::int32_t MinSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(1LL))
+      .ValueOrDefault();
+}
+}  // namespace FieldGatedByDivision
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericFieldGatedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::Read() {
+  return FieldGatedByDivision::MinSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericFieldGatedByDivisionView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
+  return FieldGatedByDivision::MinSizeInBytes();
+}
+namespace CollapsingQuotient {}  // namespace CollapsingQuotient
+
+template <class Storage>
+inline typename ::emboss::prelude::UIntView<
+    /**/ ::emboss::support::FixedSizeViewParameters<
+        8, ::emboss::support::AllValuesAreOk>,
+    typename ::emboss::support::BitBlock<
+        /**/ ::emboss::support::LittleEndianByteOrderer<
+            typename Storage::template OffsetStorageType</**/ 0, 0>>,
+        8>>
+
+GenericCollapsingQuotientView<Storage>::divisor() const {
+  if (has_divisor().ValueOr(false)) {
+    auto emboss_reserved_local_size =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(1LL));
+    auto emboss_reserved_local_offset =
+        ::emboss::support::Maybe</**/ ::std::int32_t>(
+            static_cast</**/ ::std::int32_t>(0LL));
+    if (emboss_reserved_local_size.Known() &&
+        emboss_reserved_local_size.ValueOr(0) >= 0 &&
+        emboss_reserved_local_offset.Known() &&
+        emboss_reserved_local_offset.ValueOr(0) >= 0) {
+      return ::emboss::prelude::UIntView<
+          /**/ ::emboss::support::FixedSizeViewParameters<
+              8, ::emboss::support::AllValuesAreOk>,
+          typename ::emboss::support::BitBlock<
+              /**/ ::emboss::support::LittleEndianByteOrderer<
+                  typename Storage::template OffsetStorageType</**/ 0, 0>>,
+              8>>
+
+          (backing_.template GetOffsetStorage<0, 0>(
+              emboss_reserved_local_offset.ValueOrDefault(),
+              emboss_reserved_local_size.ValueOrDefault()));
+    }
+  }
+  return ::emboss::prelude::UIntView<
+      /**/ ::emboss::support::FixedSizeViewParameters<
+          8, ::emboss::support::AllValuesAreOk>,
+      typename ::emboss::support::BitBlock<
+          /**/ ::emboss::support::LittleEndianByteOrderer<
+              typename Storage::template OffsetStorageType</**/ 0, 0>>,
+          8>>
+
+      ();
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericCollapsingQuotientView<Storage>::has_divisor() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+template <class Storage>
+inline typename GenericCollapsingQuotientView<
+    Storage>::EmbossReservedVirtualZeroOrUndefinedView
+GenericCollapsingQuotientView<Storage>::zero_or_undefined() const {
+  return typename GenericCollapsingQuotientView<
+      Storage>::EmbossReservedVirtualZeroOrUndefinedView(*this);
+}
+
+template <class Storage>
+inline ::emboss::support::Maybe<bool>
+GenericCollapsingQuotientView<Storage>::has_zero_or_undefined() const {
+  return ::emboss::support::Maybe</**/ bool>(true);
+}
+
+namespace CollapsingQuotient {
+inline constexpr ::std::int32_t IntrinsicSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(1LL))
+      .ValueOrDefault();
+}
+}  // namespace CollapsingQuotient
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<
+    Storage>::EmbossReservedDollarVirtualIntrinsicSizeInBytesView::Read() {
+  return CollapsingQuotient::IntrinsicSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<Storage>::
+    EmbossReservedDollarVirtualIntrinsicSizeInBytesView::UncheckedRead() {
+  return CollapsingQuotient::IntrinsicSizeInBytes();
+}
+
+namespace CollapsingQuotient {
+inline constexpr ::std::int32_t MaxSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(1LL))
+      .ValueOrDefault();
+}
+}  // namespace CollapsingQuotient
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::Read() {
+  return CollapsingQuotient::MaxSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<
+    Storage>::EmbossReservedDollarVirtualMaxSizeInBytesView::UncheckedRead() {
+  return CollapsingQuotient::MaxSizeInBytes();
+}
+
+namespace CollapsingQuotient {
+inline constexpr ::std::int32_t MinSizeInBytes() {
+  return ::emboss::support::Maybe</**/ ::std::int32_t>(
+             static_cast</**/ ::std::int32_t>(1LL))
+      .ValueOrDefault();
+}
+}  // namespace CollapsingQuotient
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::Read() {
+  return CollapsingQuotient::MinSizeInBytes();
+}
+
+template <class Storage>
+inline constexpr ::std::int32_t GenericCollapsingQuotientView<
+    Storage>::EmbossReservedDollarVirtualMinSizeInBytesView::UncheckedRead() {
+  return CollapsingQuotient::MinSizeInBytes();
 }
 
 }  // namespace test


### PR DESCRIPTION
Part 2 of 3 of the integer division/modulus series.

**Stacked on #273** (base branch: `emboss/divmod-operators`). Review/merge #273
first; the base retargets to `master` automatically once #273 merges. The diff
below is only this phase's changes.

Relaxes the strict division-by-zero rejection from part 1: a divisor that is
merely *possibly* zero is now allowed and propagates an `undefined` value
through the expression type system, instead of being a blanket compile error.
Only a *provably always* zero divisor (range exactly `{0}`, e.g. `x // 0`)
remains a hard error.

At runtime a `// 0` (or `% 0`) yields an Unknown `Maybe`, which poisons the
enclosing expression -- a field's size, existence condition, or value -- so
`Ok()` becomes false with no undefined behavior, rather than the whole schema
failing to compile.

## What this does
- **`ir_data.py`:** a separate `can_be_undefined` boolean flag on `IntegerType`
  and `BooleanType` (never an in-band sentinel in
  `minimum_value`/`maximum_value`/`modulus`/`modular_value`, so the many sites
  that parse those as integers are unaffected).
- **`expression_bounds.py`:** `//`/`%` introduce the flag when the divisor's
  range includes zero; additive, multiplicative, comparison (incl. `&&`/`||`),
  choice, and `$max` combinators propagate it.
- **`ir_util.py` / `header_generator.py`:** a value that can be undefined is not
  a compile-time constant even when its defined range collapses to a single
  value (e.g. `0 // d` folds to `{0}`), so `is_constant_type`, `constant_value`,
  and the codegen literal-folding shortcut all decline to fold it.
- **`constraints.py`:** narrow the divisor check to provably-always-zero.
- **`emboss_arithmetic.h`:** rewrite `FlooringQuotient` / `FlooringRemainder` as
  hand-written "special ops" (like And/Or/Choice) that return an Unknown `Maybe`
  when the divisor is zero, even with both operands Known.
- **Soundness guard** for the `Ok()`/switch discriminant optimization: an
  existence condition that can be undefined is never treated as provably known.
  A differential test (`FieldGatedByDivision`) asserts the runtime `Ok()`
  behavior for a zero divisor.
- Tests + regenerated golden.

`IsComplete()` still returns false for a `/0` size here; part 3 makes it return
true (the design doc's preferred behavior).

`bazel test //...` is green.


---
**PR chain (merge in order):** #273 → #274 (this) → #275
